### PR TITLE
Move babel-runtime from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "babel-preset-react": "^6.0.0",
     "babel-preset-stage-0": "^6.0.0",
     "babel-register": "^6.6.0",
-    "babel-runtime": "^6.9.2",
     "core-js": "^1.1.4",
     "css-loader": "^0.23.0",
     "enzyme": "^2.2.0",
@@ -76,6 +75,7 @@
     "react": "^0.14.0 || ^15.0.0-0"
   },
   "dependencies": {
+    "babel-runtime": "^6.9.2",
     "is-dom": "^1.0.5"
   }
 }


### PR DESCRIPTION
I think babel-runtime needs to be a dependency in order for react-inspector to work. Without babel-runtime on my system, webpack gives me errors like:

> ERROR in ./~/react-inspector/lib/index.js
> Module not found: Error: Cannot resolve module 'babel-runtime/helpers/extends' in [MY_CODE_DIRECTORY]/node_modules/react-inspector/lib
> @ ./~/react-inspector/lib/index.js 9:16-56

And the [Babel docs](https://babeljs.io/docs/plugins/transform-runtime/) strongly suggest that babel-runtime is supposed to be included as a dependency.

But please let me know if there's another approach expected here, or if I'm doing something wrong.

Thanks!
