### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The component accepts the following props:
 #### `expandPaths: PropTypes.oneOfType([PropTypes.string, PropTypes.array])`: an array containing all the paths that should be expanded when the component is initialized, or a string of just one path
 - The path string is similar to [JSONPath](http://goessner.net/articles/JsonPath/).
   - It is a dot separated string like `$.foo.bar`. `$.foo.bar` expands the path `$.foo.bar` where `$` refers to the root node. Note that it only expands that single node (but not all its parents and the root node). Instead, you should use `expandPaths={['$', '$.foo', '$.foo.bar']}` to expand all the way to the `$.foo.bar` node.
+  - You can refer to array index paths using `['$', '$.1']`
   - You can use wildcard to expand all paths on a specific level
     - For example, to expand all first level and second level nodes, use `['$', '$.*']` (equivalent to `expandLevel={2}`)
 - the results are merged with expandLevel


### PR DESCRIPTION
You can refer to array index paths using `['$', '$.1']`