### PR TITLE
Allow multiple attributes in DOM inspector

### DIFF
--- a/lib/dom-inspector/DOMNodePreview.js
+++ b/lib/dom-inspector/DOMNodePreview.js
@@ -33,8 +33,8 @@ var OpenTag = function OpenTag(_ref) {
       tagName
     ),
     function () {
-      var attributeNodes = [];
       if (attributes) {
+        var attributeNodes = [];
         for (var i = 0; i < attributes.length; i++) {
           var attribute = attributes[i];
           attributeNodes.push(_react2.default.createElement(
@@ -54,8 +54,8 @@ var OpenTag = function OpenTag(_ref) {
             ),
             '"'
           ));
-          return attributeNodes;
         }
+        return attributeNodes;
       }
     }(),
     '>'

--- a/src/dom-inspector/DOMNodePreview.js
+++ b/src/dom-inspector/DOMNodePreview.js
@@ -12,8 +12,8 @@ const OpenTag = ({ tagName, attributes, styles }) => {
       </span>
 
       {(()=>{
-        let attributeNodes = []
         if(attributes){
+          let attributeNodes = []
           for(let i = 0; i < attributes.length; i++){
             const attribute = attributes[i]
             attributeNodes.push(
@@ -29,8 +29,8 @@ const OpenTag = ({ tagName, attributes, styles }) => {
                               {'"'}
                             </span>
                           )
-            return attributeNodes
           }
+          return attributeNodes
         }
       })()}
 

--- a/stories/dom-inspector.js
+++ b/stories/dom-inspector.js
@@ -12,8 +12,9 @@ storiesOf('DOM Node', module)
     // div.dataset
     return <Inspector data={div}/>
   })
-  .add('Element Node: div with style', () => {
+  .add('Element Node: div with class and style', () => {
     const div = document.createElement('div')
+    div.setAttribute('class', 'test')
     div.setAttribute('style', 'font-weight: bold;')
     return <Inspector data={div}/>
   })


### PR DESCRIPTION
Thanks for making react-inspector! I noticed that the `DOMInspector` component doesn't seem to support multiple DOM attributes, this PR should fix that.

Let me know if there's anything I can do to help get this merged!