### PR TITLE
Add support for custom nodeRenderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ The component accepts the following props:
 
 #### `sortObjectKeys: PropTypes.oneOfType([PropTypes.bool, PropTypes.func])`: Sort object keys with optional compare function.
 
+#### `nodeRenderer: PropTypes.func`: Use a custom `nodeRenderer` to render the object properties (optional)
+- Instead of using the default `nodeRenderer`, you can provide a
+  custom function for rendering object properties. The _default_
+  nodeRender looks like this:
+  ```
+  import { ObjectRootLabel } from 'react-inspector'
+  import { ObjectLabel } from 'react-inspector'
+
+  const defaultNodeRenderer = ({ depth, name, data, isNonenumerable }) =>
+    depth === 0
+      ? <ObjectRootLabel name={name} data={data} />
+      : <ObjectLabel name={name} data={data} isNonenumerable={isNonenumerable} />;
+  ```
+
 ### &lt;TableInspector />
 Like `console.table`.
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,8 @@ export DOMInspector from './dom-inspector/DOMInspector';
 export ObjectLabel from './object-inspector/ObjectLabel'
 export ObjectRootLabel from './object-inspector/ObjectRootLabel'
 
-// NOTE: ObjectValue and ObjectPreview can be used as building blocks, but currently their styles are not complete
-// export ObjectValue from './object/ObjectValue'
-// export ObjectPreview from './object/ObjectPreview'
+export ObjectValue from './object/ObjectValue'
+export ObjectPreview from './object/ObjectPreview'
 
 // Wrapping the inspectors
 import ObjectInspector from './object-inspector/ObjectInspector';

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,9 @@ export ObjectInspector from './object-inspector/ObjectInspector';
 export TableInspector from './table-inspector/TableInspector';
 export DOMInspector from './dom-inspector/DOMInspector';
 
+export ObjectLabel from './object-inspector/ObjectLabel'
+export ObjectRootLabel from './object-inspector/ObjectRootLabel'
+
 // NOTE: ObjectValue and ObjectPreview can be used as building blocks, but currently their styles are not complete
 // export ObjectValue from './object/ObjectValue'
 // export ObjectPreview from './object/ObjectPreview'

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ export ObjectLabel from './object-inspector/ObjectLabel'
 export ObjectRootLabel from './object-inspector/ObjectRootLabel'
 
 export ObjectValue from './object/ObjectValue'
-export ObjectPreview from './object/ObjectPreview'
+export ObjectName from './object/ObjectName'
 
 // Wrapping the inspectors
 import ObjectInspector from './object-inspector/ObjectInspector';

--- a/src/object-inspector/ObjectInspector.js
+++ b/src/object-inspector/ObjectInspector.js
@@ -79,7 +79,7 @@ const createIterator = (showNonenumerable, sortObjectKeys) => {
   return objectIterator;
 };
 
-const nodeRenderer = ({ depth, name, data, isNonenumerable }) =>
+const defaultNodeRenderer = ({ depth, name, data, isNonenumerable }) =>
   depth === 0
     ? <ObjectRootLabel name={name} data={data} />
     : <ObjectLabel name={name} data={data} isNonenumerable={isNonenumerable} />;
@@ -111,11 +111,16 @@ class ObjectInspector extends Component {
     showNonenumerable: PropTypes.bool,
     /** Sort object keys with optional compare function. */
     sortObjectKeys: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+
+    /** Provide a custom nodeRenderer */
+    nodeRenderer: PropTypes.func,
   };
 
   render() {
     const { showNonenumerable, sortObjectKeys, ...rest } = this.props;
     const dataIterator = createIterator(showNonenumerable, sortObjectKeys);
+
+    const renderer = nodeRenderer ? nodeRenderer : defaultNodeRenderer
 
     return (
       <ThemeProvider theme={this.props.theme}>

--- a/src/object-inspector/ObjectInspector.js
+++ b/src/object-inspector/ObjectInspector.js
@@ -117,14 +117,18 @@ class ObjectInspector extends Component {
   };
 
   render() {
-    const { showNonenumerable, sortObjectKeys, ...rest } = this.props;
+    const { showNonenumerable, sortObjectKeys, nodeRenderer, ...rest } = this.props;
     const dataIterator = createIterator(showNonenumerable, sortObjectKeys);
 
     const renderer = nodeRenderer ? nodeRenderer : defaultNodeRenderer
 
     return (
       <ThemeProvider theme={this.props.theme}>
-        <TreeView nodeRenderer={nodeRenderer} dataIterator={dataIterator} {...rest} />
+        <TreeView
+          nodeRenderer={renderer}
+          dataIterator={dataIterator}
+          {...rest}>
+        </TreeView>
       </ThemeProvider>
     );
   }

--- a/src/object-inspector/ObjectInspector.spec.js
+++ b/src/object-inspector/ObjectInspector.spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TestUtils from 'react-addons-test-utils';
+import expect from 'expect';
+import ObjectInspector from './ObjectInspector';
+
+const renderer = TestUtils.createRenderer();
+
+const defaultProps = {}
+
+describe('ObjectInspector', () => {
+  beforeEach(() => {});
+
+  it('should render', () => {
+    renderer.render(<ObjectInspector theme="testvalue" />);
+    const tree = renderer.getRenderOutput();
+    expect(tree.type).toBeA('function');
+    expect(tree.props.theme).toEqual('testvalue');
+  });
+
+  it('passes `nodeRenderer` prop to <TreeView/>', () => {
+    // Test that a custom `nodeRenderer` props is passed to <TreeView/>
+    const nodeRenderer = () => null
+    renderer.render(<ObjectInspector nodeRenderer={nodeRenderer} />);
+    const tree = renderer.getRenderOutput();
+
+    expect(tree.props.children.type).toBeA('function');
+    expect(tree.props.children.props.nodeRenderer).toEqual(nodeRenderer);
+  });
+
+});

--- a/src/object/ObjectName.js
+++ b/src/object/ObjectName.js
@@ -11,10 +11,10 @@ import createStyles from '../styles/createStyles';
  * If the property name is not enumerable (`Object.prototype.propertyIsEnumerable()`),
  * the property name will be dimmed to show the difference.
  */
-const ObjectName = ({ name, dimmed }, { theme }) => {
-  const styles = createStyles('ObjectName', theme);
-  return <span style={{ ...styles.base, ...(dimmed && styles.dimmed) }}>{name}</span>;
-};
+const ObjectName = ({ name, dimmed, styles }, { theme }) => {
+  const themeStyles = createStyles('ObjectName', theme);
+  return <span style={{...themeStyles.base, ...(dimmed && styles.dimmed), ...styles}}>{ name }</span>;
+}
 
 ObjectName.propTypes = {
   /** Property name */

--- a/src/object/ObjectName.spec.js
+++ b/src/object/ObjectName.spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TestUtils from 'react-addons-test-utils';
+import expect from 'expect';
+import ObjectName from './ObjectName';
+
+const renderer = TestUtils.createRenderer();
+
+const defaultProps = {}
+
+describe('ObjectName', () => {
+  beforeEach(() => {});
+
+  it('should render', () => {
+    renderer.render(<ObjectName name="testvalue" />);
+    const tree = renderer.getRenderOutput();
+
+    expect(tree.type).toEqual('span');
+  });
+
+  it('Accepts and applies additional `style` prop', () => {
+
+    // Test that a custom `style` props is passed and applied to <span/>
+    const style = { color: "blue" }
+    renderer.render(<ObjectName styles={style} />);
+    const tree = renderer.getRenderOutput();
+
+    expect(tree.props.style.color).toEqual('blue');
+  });
+
+});

--- a/src/object/ObjectValue.js
+++ b/src/object/ObjectValue.js
@@ -7,27 +7,29 @@ import createStyles from '../styles/createStyles';
  * Can be used to render tree node in ObjectInspector
  * or render objects in TableInspector.
  */
-const ObjectValue = ({ object }, { theme }) => {
-  const styles = createStyles('ObjectValue', theme);
+const ObjectValue = ({ object, styles }, { theme }) => {
+  const themeStyles = createStyles( 'ObjectValue', theme );
+
+  const mkStyle = key => ({ ...themeStyles[key], ...styles });
 
   switch (typeof object) {
     case 'number':
-      return <span style={styles.objectValueNumber}>{object}</span>;
+      return <span style={mkStyle('objectValueNumber')}>{object}</span>;
     case 'string':
-      return <span style={styles.objectValueString}>"{object}"</span>;
+      return <span style={mkStyle('objectValueString')}>"{object}"</span>;
     case 'boolean':
-      return <span style={styles.objectValueBoolean}>{String(object)}</span>;
+      return <span style={mkStyle('objectValueBoolean')}>{String(object)}</span>;
     case 'undefined':
-      return <span style={styles.objectValueUndefined}>undefined</span>;
+      return <span style={mkStyle('objectValueUndefined')}>undefined</span>;
     case 'object':
-      if (object === null) {
-        return <span style={styles.objectValueNull}>null</span>;
+      if(object === null){
+        return <span style={mkStyle('objectValueNull')}>null</span>;
       }
       if (object instanceof Date) {
         return <span>{object.toString()}</span>;
       }
-      if (object instanceof RegExp) {
-        return <span style={styles.objectValueRegExp}>{object.toString()}</span>;
+      if (object instanceof RegExp){
+        return <span style={mkStyle('objectValueRegExp')}>{object.toString()}</span>;
       }
       if (Array.isArray(object)) {
         return <span>{`Array[${object.length}]`}</span>;
@@ -36,12 +38,12 @@ const ObjectValue = ({ object }, { theme }) => {
     case 'function':
       return (
         <span>
-          <span style={styles.objectValueFunctionKeyword}>function</span>
-          <span style={styles.objectValueFunctionName}>&nbsp;{object.name}()</span>
+          <span style={mkStyle('objectValueFunctionKeyword')}>function</span>
+          <span style={mkStyle('objectValueFunctionName')}>&nbsp;{object.name}()</span>
         </span>
       );
     case 'symbol':
-      return <span style={styles.objectValueSymbol}>{object.toString()}</span>;
+      return <span style={mkStyle('objectValueSymbol')}>{object.toString()}</span>;
     default:
       return <span />;
   }

--- a/src/object/ObjectValue.spec.js
+++ b/src/object/ObjectValue.spec.js
@@ -122,4 +122,13 @@ describe('ObjectValue', () => {
     expect(tree.type).toBe('span');
     expect(tree.props.children).toEqual('Symbol(foo)');
   });
+
+  it('accepts and applies style from `styles` prop', () => {
+    // Custom `styles` prop gets applied to the element
+    const style = { color: "blue" }
+    renderer.render(<ObjectValue styles={style} object={""} />);
+    const tree = renderer.getRenderOutput();
+    expect(tree.props.style.color).toEqual('blue');
+  });
+
 });


### PR DESCRIPTION
This PR adds support for a custom `nodeRenderer` prop for ObjectInspector. This is a change I needed and I saw you talking about it in #19, so I thought I'd give it a shot.

Rundown of the changes:
- Add support for `nodeRenderer` prop on ObjectInspector
- Export `ObjectLabel`, `ObjectRootLabel`, `ObectName`, and `ObjectValue` so that they can be used with the custom node renderer (eg, only making minor modifications to the default renderer.)
- Add support for extra `styles` prop on `ObjectValue` and `ObjectName`.

I'm using this library in [Assertible](https://assertible.com)'s HTTP response viewer and need a way to show validations inline. These changes allow me to do things like this:

![react-inspector-node-renderer](https://cloud.githubusercontent.com/assets/7034627/21282110/8d5eb29e-c3b7-11e6-9840-23dd14a6a6d5.png)

Let me know what you think. I'm happy to make some more modifications, if required.