### PR TITLE
refactor(PropTypes): using the npm package `prop-types` instead of ge…

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "expect": "^1.14.0",
     "jasmine-core": "^2.3.4",
     "mocha": "^2.4.5",
+    "prop-types": "^15.5.8",
     "react": "^15.0.2",
     "react-addons-test-utils": "^15.0.2",
     "react-dom": "^15.0.2",

--- a/src/dom-inspector/DOMInspector.js
+++ b/src/dom-inspector/DOMInspector.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 import DOMNodePreview from './DOMNodePreview'
 import TreeView from '../tree-view/TreeView'

--- a/src/dom-inspector/DOMNodePreview.js
+++ b/src/dom-inspector/DOMNodePreview.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'
 
 import createStyles from '../styles/createStyles'
 import shouldInline from './shouldInline'

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import TableInspector from './table-inspector/TableInspector'
 import DOMInspector from './dom-inspector/DOMInspector'
 
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import isDOM from 'is-dom'
 
 const Inspector = ({ table = false, data, ...rest }) => {
@@ -28,9 +29,9 @@ const Inspector = ({ table = false, data, ...rest }) => {
 }
 
 Inspector.propTypes = {
-  data: React.PropTypes.any,
-  name: React.PropTypes.string,
-  table: React.PropTypes.bool,
+  data: PropTypes.any,
+  name: PropTypes.string,
+  table: PropTypes.bool,
 }
 
 export { Inspector }

--- a/src/object-inspector/ObjectInspector.js
+++ b/src/object-inspector/ObjectInspector.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, Children } from 'react'
+import React, { Component, Children } from 'react'
+import PropTypes from 'prop-types'
 import TreeView from '../tree-view/TreeView'
 
 import ObjectRootLabel from './ObjectRootLabel'

--- a/src/object-inspector/ObjectLabel.js
+++ b/src/object-inspector/ObjectLabel.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import ObjectName from '../object/ObjectName'
 import ObjectValue from '../object/ObjectValue'
 

--- a/src/object-inspector/ObjectPreview.js
+++ b/src/object-inspector/ObjectPreview.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types'
 
 import ObjectValue from '../object/ObjectValue';
 import ObjectName from '../object/ObjectName'

--- a/src/object-inspector/ObjectRootLabel.js
+++ b/src/object-inspector/ObjectRootLabel.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import ObjectName from '../object/ObjectName'
 import ObjectPreview from './ObjectPreview'
 

--- a/src/object/ObjectName.js
+++ b/src/object/ObjectName.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import createStyles from '../styles/createStyles'
 
 /**
@@ -27,7 +28,7 @@ ObjectName.defaultProps = {
 }
 
 ObjectName.contextTypes = {
-  theme: React.PropTypes.oneOfType([PropTypes.string, PropTypes.object])
+  theme: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
 }
 
 export default ObjectName

--- a/src/object/ObjectValue.js
+++ b/src/object/ObjectValue.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import createStyles from '../styles/createStyles'
 
 /**

--- a/src/object/ObjectValue.spec.js
+++ b/src/object/ObjectValue.spec.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 import TestUtils from 'react-addons-test-utils'
 import expect from 'expect'
 import ObjectValue from './ObjectValue'

--- a/src/styles/ThemeProvider.js
+++ b/src/styles/ThemeProvider.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 class ThemeProvider extends Component {
   getChildContext() {

--- a/src/table-inspector/DataContainer.js
+++ b/src/table-inspector/DataContainer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import createStyles from '../styles/createStyles'
 import ObjectValue from '../object/ObjectValue'
 

--- a/src/table-inspector/HeaderContainer.js
+++ b/src/table-inspector/HeaderContainer.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import createStyles from '../styles/createStyles'
 import TH from './TH'
 

--- a/src/table-inspector/TH.js
+++ b/src/table-inspector/TH.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 import createStyles from '../styles/createStyles'
 

--- a/src/table-inspector/TableInspector.js
+++ b/src/table-inspector/TableInspector.js
@@ -5,6 +5,7 @@
  */
 
 import React, { Component } from 'react';
+import PropTypes from 'prop-types'
 import ThemeProvider from '../styles/ThemeProvider'
 import createStyles from '../styles/createStyles'
 
@@ -159,14 +160,14 @@ TableInspector.propTypes = {
   /**
    * the Javascript object you would like to inspect, either an array or an object
    */
-  data: React.PropTypes.oneOfType([
-      React.PropTypes.array,
-      React.PropTypes.object,
+  data: PropTypes.oneOfType([
+      PropTypes.array,
+      PropTypes.object,
     ]),
   /**
    * An array of the names of the columns you'd like to display in the table
    */
-  columns: React.PropTypes.array
+  columns: PropTypes.array
 }
 
 TableInspector.defaultProps = {

--- a/src/tree-view/TreeNode.js
+++ b/src/tree-view/TreeNode.js
@@ -1,4 +1,5 @@
-import React, { createElement, Component, PropTypes, Children } from 'react'
+import React, { createElement, Component, Children } from 'react'
+import PropTypes from 'prop-types'
 
 import createStyles from '../styles/createStyles'
 

--- a/src/tree-view/TreeView.js
+++ b/src/tree-view/TreeView.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 import TreeNode from './TreeNode'
 


### PR DESCRIPTION
refactor(PropTypes): using the npm package `prop-types` instead of getting these nodes from `react`

Here is the related issue: https://github.com/xyc/react-inspector/issues/25