### PR TITLE
Fix FF error with sortObjectKeys prop and sort function

### DIFF
--- a/src/object-inspector/ObjectInspector.js
+++ b/src/object-inspector/ObjectInspector.js
@@ -32,7 +32,9 @@ const createIterator = (showNonenumerable, sortObjectKeys) => {
       }
     } else {
       const keys = Object.getOwnPropertyNames(data);
-      if (typeof sortObjectKeys !== 'undefined') {
+      if (sortObjectKeys === true) {
+        keys.sort();
+      } else if (typeof sortObjectKeys === 'function') {
         keys.sort(sortObjectKeys);
       }
 


### PR DESCRIPTION
- Fixes #31 
- Tested in FF on some of the stories
- I am not sure about the `sortObjectKeys === true`, whether it should not be something looser like `Boolean(sortObjectKeys) === true`. I am relatively new to React so I am not sure what the convention is for boolean props - if they should be activated only when the value is `true` of if the value is truthy.