### PR TITLE
Fix dimmed ObjectName

### DIFF
--- a/src/object/ObjectName.js
+++ b/src/object/ObjectName.js
@@ -13,8 +13,14 @@ import createStyles from '../styles/createStyles';
  */
 const ObjectName = ({ name, dimmed, styles }, { theme }) => {
   const themeStyles = createStyles('ObjectName', theme);
+  const appliedStyles = {
+    ...themeStyles.base,
+    ...(dimmed ? themeStyles['dimmed'] : {}),
+    ...styles,
+  };
+  
   return (
-    <span style={{ ...themeStyles.base, ...(dimmed && styles.dimmed), ...styles }}>{name}</span>
+    <span style={appliedStyles}>{name}</span>
   );
 };
 

--- a/src/object/ObjectName.spec.js
+++ b/src/object/ObjectName.spec.js
@@ -4,6 +4,10 @@ import TestUtils from 'react-addons-test-utils';
 import expect from 'expect';
 import ObjectName from './ObjectName';
 
+import chromeLight from '../styles/themes/chromeLight';
+import makeTheme from '../styles/base';
+const defaultTheme = makeTheme(chromeLight);
+
 const renderer = TestUtils.createRenderer();
 
 const defaultProps = {};
@@ -16,6 +20,27 @@ describe('ObjectName', () => {
     const tree = renderer.getRenderOutput();
 
     expect(tree.type).toEqual('span');
+  });
+
+  it('should apply default theme', () => {
+    renderer.render(<ObjectName name="testvalue" />);
+    const tree = renderer.getRenderOutput();
+
+    expect(tree.props.style).toInclude(defaultTheme.ObjectName.base);
+  });
+
+  it('should apply dimming if `dimmed` prop is true', () => {
+    renderer.render(<ObjectName name="testvalue" dimmed={true}/>);
+    const tree = renderer.getRenderOutput();
+
+    expect(tree.props.style).toInclude(defaultTheme.ObjectName.dimmed);
+  });
+
+  it('should not apply dimming if `dimmed` prop is false', () => {
+    renderer.render(<ObjectName name="testvalue" dimmed={false}/>);
+    const tree = renderer.getRenderOutput();
+
+    expect(tree.props.style).toExclude(defaultTheme.ObjectName.dimmed);
   });
 
   it('Accepts and applies additional `style` prop', () => {


### PR DESCRIPTION
Problem discovered when tracking down: https://github.com/storybooks/storybook/issues/1385 

The `ObjectName` component was incorrectly applying the `dimmed` prop when set to `true`, by looking to the custom `styles` property instead of the current theme as intended. I corrected the issue along with adding tests to target this behavior. 