### PR TITLE
Fix crna+storybook

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,8 @@
 .babelrc
-.eslintrc
+.eslintrc.js
 .gitignore
 .npmignore
+.travis.yml
 jsconfig.json
 
 react-codemod
@@ -11,7 +12,8 @@ build/
 example
 server.js
 src/
-webpack.config.js
+karma.conf.js
+webpack.prod.config.js
 
 stories
 .storybook

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
+.babelrc
 .eslintrc
 .gitignore
 .npmignore


### PR DESCRIPTION
### Context
[Storybook](https://github.com/storybooks/storybook) recently switched to [babel-preset-env](https://github.com/babel/babel-preset-env) 

 https://github.com/storybooks/storybook/commit/8ab7bda83e25c37b79936bef510a2d391af4f548#diff-1327a902195fd9d1fb95d4671da92a42

For some reason, greenfield CRNA projects are picking up the `.babelrc` file in this libary
- https://github.com/storybooks/storybook/issues/1831
- https://github.com/storybooks/storybook/issues/1875

### Solution
Add `.babelrc` to `npmignore`
Republish the package

I took the liberty of ignoring the rest of the dev files in root
