### PR TITLE
Avoid React warnings in TableInspector by filtering props passed to <th>

### DIFF
--- a/src/table-inspector/TH.js
+++ b/src/table-inspector/TH.js
@@ -40,34 +40,37 @@ class TH extends Component {
 
   render() {
     // either not sorted, sort ascending or sort descending
-    const { sorted, sortAscending } = this.props;
+    const {
+      borderStyle,
+      children,
+      onClick,
+      sortAscending,
+      sorted,
+      ...props
+    } = this.props;
     const { theme } = this.context;
     const styles = createStyles('TableInspectorTH', theme);
 
     return (
       <th
-        {...this.props}
+        {...props}
         style={{
           ...styles.base,
-          ...this.props.borderStyle,
+          ...borderStyle,
           ...(this.state.hovered ? styles.base[':hover'] : {}),
         }}
         onMouseEnter={this.toggleHovered.bind(this, true)}
         onMouseLeave={this.toggleHovered.bind(this, false)}
-        onClick={this.props.onClick}
+        onClick={onClick}
       >
         <div style={styles.div}>
-          {this.props.children}
+          {children}
         </div>
-        {(() => {
-          if (sorted) {
-            return (
-              <SortIconContainer>
-                <SortIcon sortAscending={sortAscending} />
-              </SortIconContainer>
-            );
-          }
-        })()}
+        {sorted && (
+          <SortIconContainer>
+            <SortIcon sortAscending={sortAscending} />
+          </SortIconContainer>
+        )}
       </th>
     );
   }


### PR DESCRIPTION
Without this patch, React in dev mode will spew warnings such as:

```
Warning: React does not recognize the `sortAscending` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `sortascending` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in th (created by TH)
    in TH (created by HeaderContainer)
    in tr (created by HeaderContainer)
    in tbody (created by HeaderContainer)
    in table (created by HeaderContainer)
    in div (created by HeaderContainer)
    in HeaderContainer (created by TableInspector)
    in div (created by TableInspector)
    in ThemeProvider (created by TableInspector)
    in TableInspector (created by ...)
```