### PR TITLE
Show buffers as Buffer[${buffer.length}]

### DIFF
--- a/src/object/ObjectValue.js
+++ b/src/object/ObjectValue.js
@@ -54,9 +54,11 @@ const ObjectValue = ({ object, styles }, { theme }) => {
       if (Array.isArray(object)) {
         return <span>{`Array[${object.length}]`}</span>;
       }
-
       if (!object.constructor) {
         return <span>Object</span>;
+      }
+      if (object.constructor.isBuffer && object.constructor.isBuffer(object)) {
+        return <span>{`Buffer[${object.length}]`}</span>;
       }
 
       return (

--- a/src/object/ObjectValue.js
+++ b/src/object/ObjectValue.js
@@ -57,7 +57,7 @@ const ObjectValue = ({ object, styles }, { theme }) => {
       if (!object.constructor) {
         return <span>Object</span>;
       }
-      if (object.constructor.isBuffer && object.constructor.isBuffer(object)) {
+      if (typeof object.constructor.isBuffer === 'function' && object.constructor.isBuffer(object)) {
         return <span>{`Buffer[${object.length}]`}</span>;
       }
 


### PR DESCRIPTION
Add object value label for [Buffer](https://github.com/feross/buffer)

<img width="695" alt="screenshot 2018-07-03 16 22 05" src="https://user-images.githubusercontent.com/58871/42229032-5b8dcb14-7edd-11e8-839e-c094a2fa17f0.png">

The test is the same one as done in (is-buffer)[https://github.com/feross/is-buffer/blob/e05c7852e1a978b81c7eb6d677c861a7dc935ead/index.js#L10]

The Buffer constructor shim often gets renamed in minified code, so would otherwise appear as a single character without this check.

<img width="639" alt="screenshot 2018-07-03 16 28 26" src="https://user-images.githubusercontent.com/58871/42229332-24d1ad38-7ede-11e8-8b0e-3fc82d654326.png">


