### PR TITLE
Pin node version in .travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
   - "node"
+install:
+  # We have a yarn.lock checked in, so travis will use `yarn`, but we
+  # want to use `npm install` instead.
+  - npm install
 script:
   - npm run lint
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: node_js
 node_js:
-  - "node"
-install:
-  # We have a yarn.lock checked in, so travis will use `yarn`, but we
-  # want to use `npm install` instead.
-  - npm install
+  - "9.11.1"
 script:
   - npm run lint
   - npm test


### PR DESCRIPTION
This pins the node.js version in travis-ci to 9.11.1 because version 10+ throws a deprecation warning on `Buffer` in node 10 that fails the build.

Basically this: https://github.com/yarnpkg/yarn/issues/5770#issuecomment-385791583

My initial assumption about using npm instead of yarn was wrong because we've been using yarn. But the build is passing again now.