### PR TITLE
Make prop-types a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "is-dom": "^1.0.9"
+    "is-dom": "^1.0.9",
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@storybook/react": "^3.4.0",
@@ -65,7 +66,6 @@
     "expect": "^22.4.3",
     "jest": "^22.4.3",
     "prettier": "^1.11.1",
-    "prop-types": "^15.6.1",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",
     "react-hot-loader": "^4.0.1",


### PR DESCRIPTION
`prop-types` must be either a production dependency or a peer dependency, as it's used by the package's code.

I'd vote for a production dependency here, since many people won't have `prop-types` installed in there project (everyone using TypeScript or Flow) and whether this package uses `prop-types` or not rather seems like an implementation detail the package user should not have to care about :)

Will also make [bundlephobia show its size](https://bundlephobia.com/result?p=react-inspector@2.3.0).

<img width="1333" alt="bildschirmfoto 2018-09-30 um 08 57 35" src="https://user-images.githubusercontent.com/1842462/46254390-0ea71b00-c48f-11e8-9032-b7de338a6176.png">
