### PR TITLE
Fix the order of array key when sortObjectKeys = true is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ The component accepts the following props:
 
 #### `sortObjectKeys: PropTypes.oneOfType([PropTypes.bool, PropTypes.func])`: Sort object keys with optional compare function.
 
-#### `nodeRenderer: PropTypes.func`: Use a custom `nodeRenderer` to render the object properties (optional)
+When `sortObjectKeys={true}` is provided, keys of objects are sorted in alphabetical order except for arrays.
+
+#### `nodeRenderer: PropTypes.func`: Use a custom `nodeRenderer` to render the object properties (optional
 - Instead of using the default `nodeRenderer`, you can provide a
   custom function for rendering object properties. The _default_
   nodeRender looks like this:

--- a/src/object-inspector/ObjectInspector.js
+++ b/src/object-inspector/ObjectInspector.js
@@ -12,10 +12,10 @@ const createIterator = (showNonenumerable, sortObjectKeys) => {
     const shouldIterate = (typeof data === 'object' && data !== null) || typeof data === 'function';
     if (!shouldIterate) return;
 
-    const isArray = Array.isArray(data);
+    const dataIsArray = Array.isArray(data);
 
     // iterable objects (except arrays)
-    if (!isArray && data[Symbol.iterator]) {
+    if (!dataIsArray && data[Symbol.iterator]) {
       let i = 0;
       for (let entry of data) {
         if (Array.isArray(entry) && entry.length === 2) {
@@ -34,7 +34,7 @@ const createIterator = (showNonenumerable, sortObjectKeys) => {
       }
     } else {
       const keys = Object.getOwnPropertyNames(data);
-      if (sortObjectKeys === true && !isArray) {
+      if (sortObjectKeys === true && !dataIsArray) {
         // Array keys should not be sorted in alphabetical order
         keys.sort();
       } else if (typeof sortObjectKeys === 'function') {

--- a/src/object-inspector/ObjectInspector.js
+++ b/src/object-inspector/ObjectInspector.js
@@ -12,8 +12,10 @@ const createIterator = (showNonenumerable, sortObjectKeys) => {
     const shouldIterate = (typeof data === 'object' && data !== null) || typeof data === 'function';
     if (!shouldIterate) return;
 
+    const isArray = Array.isArray(data);
+
     // iterable objects (except arrays)
-    if (!Array.isArray(data) && data[Symbol.iterator]) {
+    if (!isArray && data[Symbol.iterator]) {
       let i = 0;
       for (let entry of data) {
         if (Array.isArray(entry) && entry.length === 2) {
@@ -32,7 +34,8 @@ const createIterator = (showNonenumerable, sortObjectKeys) => {
       }
     } else {
       const keys = Object.getOwnPropertyNames(data);
-      if (sortObjectKeys === true) {
+      if (sortObjectKeys === true && !isArray) {
+        // Array keys should not be sorted in alphabetical order
         keys.sort();
       } else if (typeof sortObjectKeys === 'function') {
         keys.sort(sortObjectKeys);


### PR DESCRIPTION
Currently, the order of array key is broken if `sortObjectKeys` prop is passed to `ObjectInspector` because `Array.prototype.sort()` sorts strings in array in alphabetical order by default.

![image](https://user-images.githubusercontent.com/12454556/48308260-db829c00-e5a3-11e8-855a-f2f3d21a115b.png)

That behavior seems unnatural, so I fixed to skip calling `keys.sort()` when data is an array.

I tested with Storybook, with following story.

```diff
diff --git a/stories/object-inspector.js b/stories/object-inspector.js
index 7c7a952..b5fc50c 100644
--- a/stories/object-inspector.js
+++ b/stories/object-inspector.js
@@ -35,6 +35,7 @@ storiesOf('Objects', module)
   .add('Object: Date', () => <Inspector data={new Date('2005-04-03')} />)
   .add('Object: Regular Expression', () => <Inspector data={/^.*$/} />)
   .add('Object: Array', () => <Inspector data={['cold', 'ice']} />)
+  .add('Object: Array with numbers', () => <Inspector data={[...Array(15).keys()]} sortObjectKeys />)
   .add('Object: Array with different types of elements', () => <Inspector data={['a', 1, {}]} />)
   .add('Object: Empty Object', () => <Inspector showNonenumerable expandLevel={1} data={{}} />)
   .add('Object: Empty String key', () => <Inspector data={{'': 'hi'}}/>)
```
