### PR TITLE
sets the array preview to respect maxProperties;

### DIFF
--- a/src/object-inspector/ObjectPreview.js
+++ b/src/object-inspector/ObjectPreview.js
@@ -36,15 +36,26 @@ const ObjectPreview = ({ data, maxProperties }) => {
   }
 
   if (Array.isArray(object)) {
+    let previewArray;
+    if (object.length > maxProperties) {
+      previewArray = object
+        .slice(0, maxProperties)
+        .map((element, index) => <ObjectValue key={index} object={element} />);
+      previewArray.push(<span key={"ellipsis"}>…</span>);
+    } else {
+      previewArray = object.map((element, index) => (
+        <ObjectValue key={index} object={element} />
+      ));
+    }
     return (
-      <span style={styles.preview}>
-        [
-        {intersperse(
-          object.map((element, index) => <ObjectValue key={index} object={element} />),
-          ', ',
-        )}
-        ]
-      </span>
+      <React.Fragment>
+        <span>{`Array(${object.length})`}</span>
+        <span style={styles.preview}>
+          [
+          {intersperse(previewArray, ",")}
+          ]
+        </span>
+      </React.Fragment>
     );
   } else {
     let propertyNodes = [];

--- a/src/object-inspector/ObjectPreview.js
+++ b/src/object-inspector/ObjectPreview.js
@@ -42,17 +42,6 @@ const ObjectPreview = ({ data, maxProperties }) => {
     if (object.length > maxProperties) {
       previewArray.push(<span key="ellipsis">…</span>);
     }
-    
-    if (object.length > maxProperties) {
-      previewArray = object
-        .slice(0, maxProperties)
-        .map((element, index) => <ObjectValue key={index} object={element} />);
-      previewArray.push(<span key={"ellipsis"}>…</span>);
-    } else {
-      previewArray = object.map((element, index) => (
-        <ObjectValue key={index} object={element} />
-      ));
-    }
     return (
       <React.Fragment>
         <span>{`Array(${object.length})`}</span>

--- a/src/object-inspector/ObjectPreview.js
+++ b/src/object-inspector/ObjectPreview.js
@@ -36,7 +36,13 @@ const ObjectPreview = ({ data, maxProperties }) => {
   }
 
   if (Array.isArray(object)) {
-    let previewArray;
+    const previewArray = object
+      .slice(0, maxProperties)
+      .map((element, index) => <ObjectValue key={index} object={element} />);
+    if (object.length > maxProperties) {
+      previewArray.push(<span key="ellipsis">…</span>);
+    }
+    
     if (object.length > maxProperties) {
       previewArray = object
         .slice(0, maxProperties)

--- a/src/object/ObjectValue.js
+++ b/src/object/ObjectValue.js
@@ -52,7 +52,7 @@ const ObjectValue = ({ object, styles }, { theme }) => {
         );
       }
       if (Array.isArray(object)) {
-        return <span>{`Array[${object.length}]`}</span>;
+        return <span>{`Array(${object.length})`}</span>;
       }
       if (!object.constructor) {
         return <span>Object</span>;

--- a/src/object/ObjectValue.spec.js
+++ b/src/object/ObjectValue.spec.js
@@ -49,7 +49,7 @@ describe('ObjectValue', () => {
   it('should render array with length information', () => {
     const tree = TestRenderer.create(<ObjectValue object={[1, 2, 3, 4, 5]} />).toJSON();
     expect(tree.type).toBe('span');
-    expect(tree.children).toEqual(['Array[5]']);
+    expect(tree.children).toEqual(['Array(5)']);
   });
 
   it('should render an empty object', () => {

--- a/stories/object-inspector.js
+++ b/stories/object-inspector.js
@@ -30,12 +30,34 @@ storiesOf('Null', module).add('Null', () => <Inspector data={null} />);
 
 storiesOf('Symbols', module).add('test', () => <Inspector data={Symbol.for('test')} />);
 
+// Arrays
+storiesOf('Arrays', module)
+  .add('Empty Array', () => <Inspector data={[]} />)
+  .add('Basic Array', () => <Inspector data={['cold', 'ice']} />)
+  .add('Array with different types of elements', () => (
+    <Inspector data={['a', 1, {}]} />
+  ))
+  .add('Long array', () => (
+    <Inspector data={new Array(1000).fill(0).map((x, i) => i + '')} />
+  ))
+  .add('Array with big objects', () => (
+    <Inspector data={
+      new Array(100).fill(0).map((x, i) => ({
+        key: i,
+        name: `John #${i}`,
+        dateOfBirth: new Date(i * 10e8),
+        address: `${i} Main Street`,
+        zip: 90210 + i,
+
+      }))
+    } />
+  ))
+  .add('Uint32Array', () => <Inspector data={new Uint32Array(1000)} />);
+
 // Objects
 storiesOf('Objects', module)
   .add('Object: Date', () => <Inspector data={new Date('2005-04-03')} />)
   .add('Object: Regular Expression', () => <Inspector data={/^.*$/} />)
-  .add('Object: Array', () => <Inspector data={['cold', 'ice']} />)
-  .add('Object: Array with different types of elements', () => <Inspector data={['a', 1, {}]} />)
   .add('Object: Empty Object', () => <Inspector showNonenumerable expandLevel={1} data={{}} />)
   .add('Object: Empty String key', () => <Inspector data={{'': 'hi'}}/>)
   .add('Object: Simple Object', () => (


### PR DESCRIPTION
In addition to setting the array preview to respect maxProperties, this adds an array section to story book with more examples and changes "Array[n]" to "Array(n)", per Chrome and FF.

I followed the FF devtools style, which looks closer to what you use elsewhere:
![image](https://user-images.githubusercontent.com/2380975/51434252-3faf8500-1c11-11e9-87ea-13ac001c1756.png)

For reference, Chrome does this:
![image](https://user-images.githubusercontent.com/2380975/51434263-88673e00-1c11-11e9-9c2d-397951ef66fa.png)
But since react-inspector has been using the `Array[n]` notation, I assume that is preferred.

This gets react inspector closer to the behavior of browser devtools, and can help with very long previews, as in the case of this 200 elt array (rendered without this PR):
![image](https://user-images.githubusercontent.com/2380975/51434291-370b7e80-1c12-11e9-9900-e180c9d33cbb.png)


Thanks for the great library, let me know if this PR has any issues you'd like me to fix!
