### PR TITLE
Adding the "transform-runtime" plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -19,13 +19,12 @@
     "@babel/plugin-proposal-nullish-coalescing-operator",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-optional-chaining",
-    "@babel/plugin-transform-object-assign"
+    "@babel/plugin-transform-object-assign",
+    "@babel/plugin-transform-runtime"
   ],
   "env": {
     "test": {
-      "plugins": [
-        "@babel/plugin-transform-runtime"
-      ]
+      "plugins": ["@babel/plugin-transform-runtime"]
     }
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,7 +22,10 @@ export default [
       nodeResolve({
         mainFields: ['module', 'jsnext:main', 'main'],
       }),
-      babel(),
+      commonjs({
+        include: 'node_modules/**',
+      }),
+      babel({ runtimeHelpers: true }),
     ],
   },
   {
@@ -39,7 +42,10 @@ export default [
       nodeResolve({
         mainFields: ['module', 'jsnext:main', 'main'],
       }),
-      babel(),
+      commonjs({
+        include: 'node_modules/**',
+      }),
+      babel({ runtimeHelpers: true }),
     ],
   },
   {
@@ -57,6 +63,7 @@ export default [
         mainFields: ['module', 'jsnext:main', 'main'],
       }),
       babel({
+        runtimeHelpers: true,
         exclude: 'node_modules/**',
       }),
       commonjs({


### PR DESCRIPTION
The changes in this PR fixes https://github.com/storybookjs/react-inspector/issues/84 for me.

When adding `@babel/plugin-transform-runtime` to the `.babelrc` file I ran into an issue running `npm run build`:

```
src/index.js → dist/cjs/react-inspector.js...
(!) Error when using sourcemap for reporting an error: Can't resolve original location of error.
src/styles/base.js: (1:7)
[!] Error: 'default' is not exported by node_modules/@babel/runtime/helpers/defineProperty.js
https://rollupjs.org/guide/en/#error-name-is-not-exported-by-module
src/styles/base.js (1:7)
1: import unselectable from './unselectable';
          ^
2: 
3: export default theme => ({
Error: 'default' is not exported by node_modules/@babel/runtime/helpers/defineProperty.js
```

This brought me to an issue on the rollup babel plugin's GitHub repo (https://github.com/rollup/rollup-plugin-babel/issues/135), which is why I am also adding the `commonjs` plugins to the `cjs` and `es` targets of the rollup configuration. Granted - I am not an expert on Rollup + Babel, perhaps this introduces other issues?