### PR TITLE
Move storybook-chromatic to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "is-dom": "^1.0.9",
-    "prop-types": "^15.6.1",
-    "storybook-chromatic": "^2.2.2"
+    "prop-types": "^15.6.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",
@@ -87,6 +86,7 @@
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.2",
     "rollup-plugin-node-resolve": "^4.0.1",
+    "storybook-chromatic": "^2.2.2"
     "style-loader": "^0.23.1",
     "webpack": "^4.5.0",
     "webpack-cli": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-commonjs": "^9.2.2",
     "rollup-plugin-node-resolve": "^4.0.1",
-    "storybook-chromatic": "^2.2.2"
+    "storybook-chromatic": "^2.2.2",
     "style-loader": "^0.23.1",
     "webpack": "^4.5.0",
     "webpack-cli": "^3.2.1",


### PR DESCRIPTION
It doesn't seem to be necessary to use the component. Solve

> warning "workspace-aggregator-a3500d7f-0624-4256-b99c-3391a56c3ccb > docs > react-inspector > storybook-chromatic@2.2.2" has unmet peer dependency "@storybook/core@3.* || 4.* || 5.*".

Closes #92