### PR TITLE
Update from `babel-runtime` to `@babel/runtime`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chromatic": "CHROMATIC_APP_CODE=17yeg4lpa7q chromatic test"
   },
   "dependencies": {
-    "babel-runtime": "^6.26.0",
+    "@babel/runtime": "^7.6.3",
     "is-dom": "^1.0.9",
     "prop-types": "^15.6.1",
     "storybook-chromatic": "^2.2.2"
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
-    "@babel/plugin-syntax-bigint": "^7.2.0",
     "@babel/plugin-proposal-class-properties": "^7.3.0",
     "@babel/plugin-proposal-do-expressions": "^7.2.0",
     "@babel/plugin-proposal-export-default-from": "^7.2.0",
@@ -62,6 +61,7 @@
     "@babel/plugin-proposal-nullish-coalescing-operator": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
     "@babel/plugin-proposal-optional-chaining": "^7.2.0",
+    "@babel/plugin-syntax-bigint": "^7.2.0",
     "@babel/plugin-transform-object-assign": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.4.0",
     "@babel/preset-env": "^7.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1013,6 +1013,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
+  integrity sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.2.2", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"


### PR DESCRIPTION
As requested when I commented in #77 about the v6 `babel-runtime` dependency still using `core-js` v2, here's a PR to replace it with the v7 `@babel/runtime`.

@ndelangen can you confirm that the version differences mentioned in the [Babel v7 migration guide](https://babeljs.io/docs/en/v7-migration#babel-runtime-babel-plugin-transform-runtime) about `@babel/plugin-transform-runtime` are okay?