### PR TITLE
Prevent component crashes on getters that throw

### DIFF
--- a/src/object-inspector/ObjectInspector.js
+++ b/src/object-inspector/ObjectInspector.js
@@ -6,6 +6,7 @@ import ObjectRootLabel from './ObjectRootLabel';
 import ObjectLabel from './ObjectLabel';
 
 import { propertyIsEnumerable } from '../utils/objectPrototype';
+import { getPropertyValue } from '../utils/propertyUtils';
 
 import { themeAcceptor } from '../styles';
 
@@ -44,9 +45,9 @@ const createIterator = (showNonenumerable, sortObjectKeys) => {
         keys.sort(sortObjectKeys);
       }
 
-      for (let propertyName of keys) {
+      for (const propertyName of keys) {
         if (propertyIsEnumerable.call(data, propertyName)) {
-          const propertyValue = data[propertyName];
+          const propertyValue = getPropertyValue(data, propertyName);
           yield {
             name: propertyName || `""`,
             data: propertyValue,
@@ -57,7 +58,7 @@ const createIterator = (showNonenumerable, sortObjectKeys) => {
           // http://stackoverflow.com/questions/31921189/caller-and-arguments-are-restricted-function-properties-and-cannot-be-access
           let propertyValue;
           try {
-            propertyValue = data[propertyName];
+            propertyValue = getPropertyValue(data, propertyName);
           } catch (e) {
             // console.warn(e)
           }

--- a/src/object-inspector/ObjectPreview.js
+++ b/src/object-inspector/ObjectPreview.js
@@ -6,6 +6,7 @@ import ObjectName from '../object/ObjectName';
 import { useStyles } from '../styles';
 
 import { hasOwnProperty } from '../utils/objectPrototype';
+import { getPropertyValue } from "../utils/propertyUtils";
 
 /* intersperse arr with separator */
 function intersperse(arr, sep) {
@@ -52,8 +53,7 @@ const ObjectPreview = ({ data }) => {
   } else {
     const maxProperties = styles.objectMaxProperties;
     let propertyNodes = [];
-    for (let propertyName in object) {
-      const propertyValue = object[propertyName];
+    for (const propertyName in object) {
       if (hasOwnProperty.call(object, propertyName)) {
         let ellipsis;
         if (
@@ -62,6 +62,8 @@ const ObjectPreview = ({ data }) => {
         ) {
           ellipsis = <span key={'ellipsis'}>…</span>;
         }
+
+        const propertyValue = getPropertyValue(object, propertyName);
         propertyNodes.push(
           <span key={propertyName}>
             <ObjectName name={propertyName || `""`} />

--- a/src/utils/propertyUtils.js
+++ b/src/utils/propertyUtils.js
@@ -1,0 +1,13 @@
+export function getPropertyValue(object, propertyName) {
+    const propertyDescriptor = Object.getOwnPropertyDescriptor(object, propertyName);
+    if (propertyDescriptor.get) {
+        try {
+            return propertyDescriptor.get()
+        }
+        catch {
+            return propertyDescriptor.get
+        }
+    }
+
+    return object[propertyName];
+}

--- a/stories/object-inspector.js
+++ b/stories/object-inspector.js
@@ -64,7 +64,13 @@ storiesOf('Objects', module)
   .add('Object: Date', () => <Inspector data={new Date('2005-04-03')} />)
   .add('Object: Regular Expression', () => <Inspector data={/^.*$/} />)
   .add('Object: Empty Object', () => <Inspector showNonenumerable expandLevel={1} data={{}} />)
-  .add('Object: Empty String key', () => <Inspector data={{'': 'hi'}}/>)
+  .add('Object: Empty String key', () => <Inspector data={{ '': 'hi' }} />)
+  .add('Object: Object with getter property', () => (
+    <Inspector expandLevel={2} data={{ get prop() { return "v" } }} />
+  ))
+  .add('Object: Object with getter property that throws', () => (
+    <Inspector expandLevel={2} data={{ get prop() { throw new Error() } }} />
+  ))
   .add('Object: Simple Object', () => (
     <Inspector showNonenumerable expandLevel={2} data={{ k: 'v' }} />
   ))


### PR DESCRIPTION
This fix prevents component crashes on getters that throw errors, somewhat similar to how it currently behaves in the browser console.

Example object:

```javascript
const obj = {
  get prop() { throw "I'm going to crash the inspector"; }
}
```

Causes crashes of upstream `console-feed` components and e.g. codesandbox's console logging.