### PR TITLE
fix: reduce size of the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,6 +11,7 @@ yarn.lock
 
 react-codemod
 gh-pages
+.github/
 
 build/
 example
@@ -22,3 +23,4 @@ webpack.prod.config.js
 
 stories
 .storybook
+storybook-static/


### PR DESCRIPTION
Updated `.npmignore` file to exclude files that are not necessary in the bundle.

Package size difference:

**Before**:
```
npm notice package size:  3.8 MB
npm notice unpacked size: 16.1 MB
npm notice total files:   22
```

**After**:
```
npm notice package size:  246.8 kB
npm notice unpacked size: 1.0 MB
npm notice total files:   11
```