### PR TITLE
Add `onExpand` callback when node are expanded/collapsed

### DIFF
--- a/src/object-inspector/ObjectInspector.tsx
+++ b/src/object-inspector/ObjectInspector.tsx
@@ -120,6 +120,9 @@ const ObjectInspector: FC<any> = ({ showNonenumerable = false, sortObjectKeys, n
 
 //   /** Provide a custom nodeRenderer */
 //   nodeRenderer: PropTypes.func,
+//
+//   /** Callback when node is clicked */
+//   onExpand: PropTypes.func,
 // };
 
 const themedObjectInspector = themeAcceptor(ObjectInspector);

--- a/src/tree-view/TreeView.tsx
+++ b/src/tree-view/TreeView.tsx
@@ -11,23 +11,20 @@ const ConnectedTreeNode = memo<any>((props) => {
   const nodeHasChildNodes = hasChildNodes(data, dataIterator);
   const expanded = !!expandedPaths[path];
 
-  const handleClick = useCallback(
-    () =>
-      nodeHasChildNodes &&
-      setExpandedPaths((prevExpandedPaths) => {
-        const newExpandedPaths = {
-          ...prevExpandedPaths,
-          [path]: !expanded,
-        };
+  const handleClick = useCallback(() => {
+    if (!nodeHasChildNodes) {
+      return;
+    }
 
-        if (typeof onExpand === 'function') {
-          onExpand(path, newExpandedPaths);
-        }
+    setExpandedPaths((prevExpandedPaths) => ({
+      ...prevExpandedPaths,
+      [path]: !expanded,
+    }));
 
-        return newExpandedPaths;
-      }),
-    [nodeHasChildNodes, setExpandedPaths, path, expanded, onExpand]
-  );
+    if (typeof onExpand === 'function') {
+      onExpand(path, { ...expandedPaths, [path]: !expanded });
+    }
+  }, [nodeHasChildNodes, setExpandedPaths, path, expanded, onExpand]);
 
   return (
     <TreeNode
@@ -54,6 +51,7 @@ const ConnectedTreeNode = memo<any>((props) => {
                   key={name}
                   dataIterator={dataIterator}
                   nodeRenderer={nodeRenderer}
+                  onExpand={onExpand}
                   {...renderNodeProps}
                 />
               );


### PR DESCRIPTION
This adds an `onExpand` callback to `TreeView` that is called when nodes are expanded and collapsed.