### PR TITLE
CI: Fix release not pushing to `main`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,10 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: (contains(github.event.head_commit.message, 'skip-release') == false) && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-release'))
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
-    strategy:
-      matrix:
-        node-version: [22]
     steps:
       - uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-inspector",
-  "version": "7.0.0",
+  "version": "8.0.0",
   "description": "Power of Browser DevTools inspectors right inside your React app",
   "keywords": [
     "devtools",


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.0.1--canary.192.17428562973.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-inspector@8.0.1--canary.192.17428562973.0
  # or 
  yarn add react-inspector@8.0.1--canary.192.17428562973.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
