### PR TITLE
Add Effect Schema support for enhanced inspector display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 *.log
 storybook-static
 .yarn/*
+.playwright-mcp

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -1,0 +1,53 @@
+# Fork Changelog
+
+This document tracks all changes made in this fork relative to [upstream storybookjs/react-inspector](https://github.com/storybookjs/react-inspector).
+
+## Keeping This Changelog Up to Date
+
+**Important:** This changelog must be updated whenever:
+
+1. **Adding fork-specific changes** - Document every modification made in this fork
+2. **Syncing with upstream** - Note the upstream commit/tag synced to and any merge conflicts resolved
+3. **Removing fork changes** - If a feature is merged upstream and removed from the fork
+
+Each entry should include:
+- Date of change
+- Brief description of what changed
+- Link to relevant PR/commit if applicable
+
+---
+
+## Upstream Base
+
+**Last synced:** 2024-12-17
+**Upstream commit:** `c0cfe13` (HEAD of main)
+**Upstream version:** 8.0.0
+
+---
+
+## Fork Changes
+
+### Planned
+
+- [ ] Effect Schema support - Native rendering for Effect Schema types
+- [ ] Minor improvements and fixes
+
+### Added
+
+*No changes yet - fork just initialized.*
+
+### Changed
+
+*No changes yet.*
+
+### Fixed
+
+*No changes yet.*
+
+---
+
+## Sync History
+
+| Date | Upstream Commit | Notes |
+|------|-----------------|-------|
+| 2024-12-17 | `c0cfe13` | Initial fork from upstream |

--- a/FORK_CHANGELOG.md
+++ b/FORK_CHANGELOG.md
@@ -25,16 +25,66 @@ Each entry should include:
 
 ---
 
+## Fork Principles
+
+**Keep changes isolated**: New features should be implemented in new files whenever possible, with minimal modifications to existing upstream files. This makes it easier to:
+- Track fork-specific changes
+- Sync with upstream updates
+- Review and maintain the fork
+
 ## Fork Changes
 
 ### Planned
 
-- [ ] Effect Schema support - Native rendering for Effect Schema types
 - [ ] Minor improvements and fixes
 
 ### Added
 
-*No changes yet - fork just initialized.*
+#### Effect Schema Support (2024-12-17)
+
+Optional support for Effect Schema annotations to enrich the inspector display.
+
+**New files added** (all in `src/schema/`):
+- `effectSchema.tsx` - Core utilities for extracting Effect Schema annotations
+- `SchemaContext.tsx` - React context for passing schema info down the tree
+- `SchemaAwareObjectInspector.tsx` - HOC to add schema support to ObjectInspector
+- `SchemaAwareObjectValue.tsx` - Schema-aware wrapper for ObjectValue
+- `SchemaAwareObjectPreview.tsx` - Schema-aware wrapper for ObjectPreview
+- `mod.tsx` - Module exports
+
+**New story added**:
+- `stories/effect-schema.stories.tsx` - Storybook stories demonstrating schema features
+
+**Minimal changes to existing files**:
+- `package.json` - Added `effect` as optional peer dependency
+- `src/index.tsx` - Added re-exports for schema utilities (clearly marked section)
+
+**Features**:
+- `withSchemaSupport(ObjectInspector)` - HOC to create a schema-aware inspector
+- `SchemaProvider` - Context provider for schema information
+- Uses schema `title` or `identifier` annotation for type names
+- Uses schema `pretty` annotation for custom value formatting
+- Supports nested schemas for struct fields and array elements
+
+**Usage**:
+```tsx
+import { ObjectInspector, withSchemaSupport, SchemaProvider } from '@overeng/react-inspector';
+import { Schema } from 'effect';
+
+const UserSchema = Schema.Struct({
+  id: Schema.Number,
+  name: Schema.String,
+}).annotations({ title: 'User' });
+
+// Option 1: Using HOC
+const SchemaInspector = withSchemaSupport(ObjectInspector);
+<SchemaInspector data={user} schema={UserSchema} />
+
+// Option 2: Using SchemaProvider directly
+<SchemaProvider schema={UserSchema}>
+  <ObjectInspector data={user} />
+</SchemaProvider>
+```
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,94 @@ This fork adds:
 - **Effect Schema support** - Native rendering for Effect Schema types with proper inspection
 - **Minor improvements** - Small enhancements and fixes not yet merged upstream
 
+## Effect Schema Support
+
+This fork adds optional support for [Effect Schema](https://effect.website/docs/schema/introduction) to enrich the display of inspected data using schema annotations.
+
+### Features
+
+- **Type names**: Display schema type names (e.g., "User", "Order") instead of generic "Object"
+- **Pretty print**: Custom value formatting using the `pretty` annotation (e.g., `$29.99` for currency)
+- **Nested schemas**: Full support for nested object and array schemas with automatic type resolution
+
+### Comparison: With vs Without Schema
+
+![Schema comparison showing enhanced display with type names and formatting](https://iili.io/fccqBSf.png)
+
+**With Schema** (left): Shows "Order" type name, "Order Item" for array elements, and `$109.97` formatted prices.
+
+**Without Schema** (right): Shows plain `{...}` without type name, "Object" for array elements, and raw `109.97` numbers.
+
+### Nested Schema Support
+
+![Nested schema support showing Address type annotation](https://iili.io/fccquV9.png)
+
+Nested objects like `address` display their schema type name ("Address") instead of "Object".
+
+### Usage
+
+```tsx
+import { Schema } from 'effect';
+import {
+  ObjectInspector,
+  ObjectRootLabel,
+  ObjectLabel,
+  ObjectName,
+  ObjectValue,
+  ObjectPreview,
+  withSchemaSupport,
+} from '@overeng/react-inspector';
+
+// Define your schemas with annotations
+const AddressSchema = Schema.Struct({
+  street: Schema.String,
+  city: Schema.String,
+}).annotations({
+  identifier: 'Address',
+  title: 'Address',
+});
+
+const UserSchema = Schema.Struct({
+  name: Schema.String,
+  address: AddressSchema,
+}).annotations({
+  identifier: 'User',
+  title: 'User',
+});
+
+// Create a schema-aware inspector
+const SchemaObjectInspector = withSchemaSupport(ObjectInspector, {
+  ObjectRootLabel,
+  ObjectLabel,
+  ObjectName,
+  ObjectValue,
+  ObjectPreview,
+});
+
+// Use it with your data and schema
+const user = { name: 'John', address: { street: '123 Main St', city: 'NYC' } };
+
+<SchemaObjectInspector data={user} schema={UserSchema} expandLevel={2} />
+```
+
+### Pretty Print Annotation
+
+Use the `pretty` annotation for custom value formatting:
+
+```tsx
+const MoneySchema = Schema.Number.annotations({
+  identifier: 'Money',
+  pretty: (value) => `$${(value as number).toFixed(2)}`,
+});
+
+const ProductSchema = Schema.Struct({
+  name: Schema.String,
+  price: MoneySchema,
+}).annotations({ identifier: 'Product' });
+```
+
+This will display `price: $29.99` instead of `price: 29.99`.
+
 ---
 
 *Original README follows:*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
-# react-inspector
+# react-inspector ([overengineered](https://www.overengineering.studio/) fork)
+
+> **This is a fork of [storybookjs/react-inspector](https://github.com/storybookjs/react-inspector).**
+>
+> See [FORK_CHANGELOG.md](./FORK_CHANGELOG.md) for differences from upstream.
+
+## Fork Goals
+
+This fork adds:
+
+- **Effect Schema support** - Native rendering for Effect Schema types with proper inspection
+- **Minor improvements** - Small enhancements and fixes not yet merged upstream
+
+---
+
+*Original README follows:*
+
+---
 
 [![build status](https://img.shields.io/travis/storybookjs/react-inspector/master.svg?style=flat-square)](https://travis-ci.org/storybookjs/react-inspector)
 [![npm version](https://img.shields.io/npm/v/react-inspector.svg?style=flat-square)](https://www.npmjs.com/package/react-inspector)

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@typescript-eslint/parser": "^8.42.0",
     "auto": "^11.3.0",
     "chromatic": "^13.1.4",
+    "effect": "^3.12.5",
     "eslint": "^9.34.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
@@ -87,7 +88,13 @@
     "vitest": "^3.2.4"
   },
   "peerDependencies": {
+    "effect": "^3.0.0",
     "react": "^18.0.0 || ^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "effect": {
+      "optional": true
+    }
   },
   "packageManager": "yarn@4.9.4",
   "auto": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-inspector",
+  "name": "@overeng/react-inspector",
   "version": "8.0.0",
   "description": "Power of Browser DevTools inspectors right inside your React app",
   "keywords": [

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,3 +32,24 @@ interface TableInspectorProps extends ComponentProps<typeof TableInspector> {
 interface ObjectInspectorProps extends ComponentProps<typeof ObjectInspector> {
   table: false;
 }
+
+// ============================================================================
+// Fork additions: Effect Schema support
+// All new code is in src/schema/ - these are just re-exports
+// ============================================================================
+export {
+  SchemaProvider,
+  useSchemaContext,
+  useSchemaDisplayInfo,
+  type SchemaContextValue,
+  type SchemaProviderProps,
+} from './schema/mod';
+
+export {
+  withSchemaSupport,
+  withSchemaContext,
+  type SchemaAwareObjectInspectorDeps,
+} from './schema/SchemaAwareObjectInspector';
+export { createSchemaAwareNodeRenderer } from './schema/SchemaAwareNodeRenderer';
+export { SchemaAwareObjectValue } from './schema/SchemaAwareObjectValue';
+export { SchemaAwareObjectPreview } from './schema/SchemaAwareObjectPreview';

--- a/src/schema/SchemaAwareNodeRenderer.tsx
+++ b/src/schema/SchemaAwareNodeRenderer.tsx
@@ -1,0 +1,169 @@
+import React, { FC } from 'react';
+import { useSchemaContext } from './SchemaContext';
+
+export interface SchemaAwareNodeRendererProps {
+  /** Original ObjectRootLabel component */
+  ObjectRootLabel: FC<{ name?: string; data: unknown }>;
+  /** Original ObjectLabel component */
+  ObjectLabel: FC<{ name: string; data: unknown; isNonenumerable?: boolean }>;
+  /** Original ObjectName component */
+  ObjectName: FC<{ name: string; dimmed?: boolean }>;
+  /** Original ObjectValue component */
+  ObjectValue: FC<{ object: unknown }>;
+  /** Original ObjectPreview component */
+  ObjectPreview: FC<{ data: unknown }>;
+}
+
+/**
+ * Creates a schema-aware node renderer that uses schema annotations for display.
+ * Uses path-based schema lookup to resolve the correct schema for any node
+ * in the tree, including deeply nested fields.
+ */
+export const createSchemaAwareNodeRenderer = ({
+  ObjectName,
+  ObjectValue,
+  ObjectPreview,
+}: SchemaAwareNodeRendererProps) => {
+  /** Schema-aware ObjectValue that uses pretty print and display name */
+  const SchemaAwareObjectValue: FC<{ object: unknown; path: string }> = ({ object, path }) => {
+    const rootCtx = useSchemaContext();
+    const schemaCtx = rootCtx.getContextForPath(path);
+
+    const prettyFormatted = schemaCtx.formatValue(object);
+    if (prettyFormatted !== undefined) {
+      return <span>{prettyFormatted}</span>;
+    }
+
+    if (
+      typeof object === 'object' &&
+      object !== null &&
+      !(object instanceof Date) &&
+      !(object instanceof RegExp) &&
+      !Array.isArray(object)
+    ) {
+      const schemaDisplayName = schemaCtx.getDisplayName();
+      if (schemaDisplayName && object.constructor?.name === 'Object') {
+        return <span>{schemaDisplayName}</span>;
+      }
+    }
+
+    return <ObjectValue object={object} />;
+  };
+
+  /** Schema-aware ObjectPreview that uses schema annotations */
+  const SchemaAwareObjectPreview: FC<{ data: unknown; path: string }> = ({ data, path }) => {
+    const rootCtx = useSchemaContext();
+    const schemaCtx = rootCtx.getContextForPath(path);
+
+    const prettyFormatted = schemaCtx.formatValue(data);
+    if (prettyFormatted !== undefined) {
+      return <span>{prettyFormatted}</span>;
+    }
+
+    return <ObjectPreview data={data} />;
+  };
+
+  /** Schema-aware ObjectLabel that uses path-based schema lookup */
+  const SchemaAwareObjectLabel: FC<{
+    name: string;
+    data: unknown;
+    path: string;
+    isNonenumerable?: boolean;
+  }> = ({ name, data, path, isNonenumerable = false }) => {
+    return (
+      <span>
+        {typeof name === 'string' ? (
+          <ObjectName name={name} dimmed={isNonenumerable} />
+        ) : (
+          <SchemaAwareObjectPreview data={name} path={path} />
+        )}
+        <span>: </span>
+        <SchemaAwareObjectValue object={data} path={path} />
+      </span>
+    );
+  };
+
+  /** Schema-aware ObjectRootLabel */
+  const SchemaAwareObjectRootLabel: FC<{ name?: string; data: unknown; path: string }> = ({ name, data, path }) => {
+    const rootCtx = useSchemaContext();
+    const schemaCtx = rootCtx.getContextForPath(path);
+
+    const prettyFormatted = schemaCtx.formatValue(data);
+    if (prettyFormatted !== undefined) {
+      if (typeof name === 'string') {
+        return (
+          <span>
+            <ObjectName name={name} />
+            <span>: </span>
+            <span>{prettyFormatted}</span>
+          </span>
+        );
+      }
+      return <span>{prettyFormatted}</span>;
+    }
+
+    const schemaDisplayName = schemaCtx.getDisplayName();
+
+    if (typeof name === 'string') {
+      return (
+        <span>
+          <ObjectName name={name} />
+          <span>: </span>
+          <SchemaAwareObjectPreviewWithName data={data} schemaDisplayName={schemaDisplayName} />
+        </span>
+      );
+    }
+
+    return <SchemaAwareObjectPreviewWithName data={data} schemaDisplayName={schemaDisplayName} />;
+  };
+
+  /** Helper for root preview with schema name */
+  const SchemaAwareObjectPreviewWithName: FC<{
+    data: unknown;
+    schemaDisplayName?: string;
+  }> = ({ data, schemaDisplayName }) => {
+    if (
+      schemaDisplayName &&
+      typeof data === 'object' &&
+      data !== null &&
+      !(data instanceof Date) &&
+      !(data instanceof RegExp) &&
+      data.constructor?.name === 'Object'
+    ) {
+      return (
+        <span>
+          <span style={{ fontStyle: 'italic' }}>{schemaDisplayName} </span>
+          <ObjectPreview data={data} />
+        </span>
+      );
+    }
+
+    return <ObjectPreview data={data} />;
+  };
+
+  /**
+   * The node renderer function to pass to ObjectInspector.
+   * Uses the `path` prop to resolve the correct schema for each node.
+   */
+  const schemaAwareNodeRenderer = ({
+    depth,
+    name,
+    data,
+    path,
+    isNonenumerable,
+  }: {
+    depth: number;
+    name: string;
+    data: unknown;
+    path: string;
+    isNonenumerable?: boolean;
+  }) => {
+    if (depth === 0) {
+      return <SchemaAwareObjectRootLabel name={name} data={data} path={path} />;
+    }
+
+    return <SchemaAwareObjectLabel name={name} data={data} path={path} isNonenumerable={isNonenumerable} />;
+  };
+
+  return schemaAwareNodeRenderer;
+};

--- a/src/schema/SchemaAwareObjectInspector.tsx
+++ b/src/schema/SchemaAwareObjectInspector.tsx
@@ -1,0 +1,76 @@
+import React, { FC, ComponentProps, useMemo } from 'react';
+import type { Schema as S } from 'effect';
+import { SchemaProvider } from './SchemaContext';
+import { createSchemaAwareNodeRenderer } from './SchemaAwareNodeRenderer';
+
+export interface SchemaAwareObjectInspectorDeps {
+  /** Original ObjectRootLabel component */
+  ObjectRootLabel: FC<{ name?: string; data: unknown }>;
+  /** Original ObjectLabel component */
+  ObjectLabel: FC<{ name: string; data: unknown; isNonenumerable?: boolean }>;
+  /** Original ObjectName component */
+  ObjectName: FC<{ name: string; dimmed?: boolean }>;
+  /** Original ObjectValue component */
+  ObjectValue: FC<{ object: unknown }>;
+  /** Original ObjectPreview component */
+  ObjectPreview: FC<{ data: unknown }>;
+}
+
+/**
+ * HOC that wraps ObjectInspector with Effect Schema support.
+ * When a schema is provided, the inspector will use schema annotations
+ * to provide richer display information including for nested fields.
+ *
+ * @param ObjectInspector - The inspector component to wrap
+ * @param deps - Original components needed for the schema-aware renderer
+ */
+export const withSchemaSupport = <TInspector extends FC<any>>(
+  ObjectInspector: TInspector,
+  deps: SchemaAwareObjectInspectorDeps
+): FC<ComponentProps<TInspector> & { schema?: S.Schema.All; schemas?: S.Schema.All[] }> => {
+  const SchemaAwareObjectInspector: FC<
+    ComponentProps<TInspector> & { schema?: S.Schema.All; schemas?: S.Schema.All[] }
+  > = ({ schema, schemas, nodeRenderer, ...props }) => {
+    const schemaNodeRenderer = useMemo(() => createSchemaAwareNodeRenderer(deps), [deps]);
+
+    const Inspector = ObjectInspector as FC<any>;
+
+    if (schema || (schemas && schemas.length > 0)) {
+      return (
+        <SchemaProvider schema={schema} schemas={schemas}>
+          <Inspector {...props} nodeRenderer={schemaNodeRenderer} />
+        </SchemaProvider>
+      );
+    }
+
+    return <Inspector {...props} nodeRenderer={nodeRenderer} />;
+  };
+
+  return SchemaAwareObjectInspector;
+};
+
+/**
+ * Simple HOC for cases where you don't need nested schema support.
+ * Just wraps the inspector with SchemaProvider context.
+ */
+export const withSchemaContext = <TInspector extends FC<any>>(
+  ObjectInspector: TInspector
+): FC<ComponentProps<TInspector> & { schema?: S.Schema.All; schemas?: S.Schema.All[] }> => {
+  const SchemaAwareObjectInspector: FC<
+    ComponentProps<TInspector> & { schema?: S.Schema.All; schemas?: S.Schema.All[] }
+  > = ({ schema, schemas, ...props }) => {
+    const inspector = <ObjectInspector {...(props as ComponentProps<TInspector>)} />;
+
+    if (schema || (schemas && schemas.length > 0)) {
+      return (
+        <SchemaProvider schema={schema} schemas={schemas}>
+          {inspector}
+        </SchemaProvider>
+      );
+    }
+
+    return inspector;
+  };
+
+  return SchemaAwareObjectInspector;
+};

--- a/src/schema/SchemaAwareObjectPreview.tsx
+++ b/src/schema/SchemaAwareObjectPreview.tsx
@@ -1,0 +1,122 @@
+import React, { FC, ReactNode } from 'react';
+import { useSchemaContext, SchemaProvider } from './SchemaContext';
+
+export interface SchemaAwareObjectPreviewProps {
+  data: unknown;
+  /** The original ObjectPreview component to wrap */
+  ObjectPreview: FC<{ data: unknown }>;
+  /** The original ObjectValue component */
+  ObjectValue: FC<{ object: unknown }>;
+  /** The original ObjectName component */
+  ObjectName: FC<{ name: string }>;
+  /** Property utilities */
+  hasOwnProperty: (obj: object, prop: string) => boolean;
+  getPropertyValue: (obj: object, prop: string) => unknown;
+  /** Style hooks */
+  useStyles: (key: string) => Record<string, unknown>;
+}
+
+/** Intersperse array elements with a separator */
+const intersperse = (arr: ReactNode[], sep: string): ReactNode[] => {
+  if (arr.length === 0) return [];
+  return arr.slice(1).reduce<ReactNode[]>((xs, x) => xs.concat([sep, x]), [arr[0]]);
+};
+
+/**
+ * Wrapper component that adds Effect Schema support to ObjectPreview.
+ * Uses schema annotations to enrich the display:
+ * - `pretty` annotation for custom value formatting
+ * - `title` or `identifier` annotation for type names
+ * - Field-level schemas for nested property display
+ */
+export const SchemaAwareObjectPreview: FC<SchemaAwareObjectPreviewProps> = ({
+  data,
+  ObjectPreview,
+  ObjectValue,
+  ObjectName,
+  hasOwnProperty,
+  getPropertyValue,
+  useStyles,
+}) => {
+  const styles = useStyles('ObjectPreview');
+  const schemaCtx = useSchemaContext();
+  const object = data;
+
+  const prettyFormatted = schemaCtx.formatValue(object);
+  if (prettyFormatted !== undefined) {
+    return <span>{prettyFormatted}</span>;
+  }
+
+  if (!schemaCtx.schema) {
+    return <ObjectPreview data={data} />;
+  }
+
+  if (typeof object !== 'object' || object === null || object instanceof Date || object instanceof RegExp) {
+    return <ObjectValue object={object} />;
+  }
+
+  if (Array.isArray(object)) {
+    const maxProperties = (styles.arrayMaxProperties as number) || 10;
+    const elementCtx = schemaCtx.getElementContext();
+
+    const previewArray = object.slice(0, maxProperties).map((element, index) => (
+      <SchemaProvider key={index} schema={elementCtx.schema} schemas={[]}>
+        <ObjectValue object={element} />
+      </SchemaProvider>
+    ));
+    if (object.length > maxProperties) {
+      previewArray.push(<span key="ellipsis">…</span>);
+    }
+    const arrayLength = object.length;
+    return (
+      <React.Fragment>
+        <span style={styles.objectDescription as React.CSSProperties}>
+          {arrayLength === 0 ? `` : `(${arrayLength})\xa0`}
+        </span>
+        <span style={styles.preview as React.CSSProperties}>[{intersperse(previewArray, ', ')}]</span>
+      </React.Fragment>
+    );
+  } else {
+    const maxProperties = (styles.objectMaxProperties as number) || 5;
+    const propertyNodes: ReactNode[] = [];
+    for (const propertyName in object) {
+      if (hasOwnProperty(object, propertyName)) {
+        let ellipsis;
+        if (propertyNodes.length === maxProperties - 1 && Object.keys(object).length > maxProperties) {
+          ellipsis = <span key={'ellipsis'}>…</span>;
+        }
+
+        const propertyValue = getPropertyValue(object, propertyName);
+        const fieldCtx = schemaCtx.getFieldContext(propertyName);
+
+        propertyNodes.push(
+          <span key={propertyName}>
+            <ObjectName name={propertyName || `""`} />
+            :&nbsp;
+            <SchemaProvider schema={fieldCtx.schema} schemas={[]}>
+              <ObjectValue object={propertyValue} />
+            </SchemaProvider>
+            {ellipsis}
+          </span>
+        );
+        if (ellipsis) break;
+      }
+    }
+
+    const schemaDisplayName = schemaCtx.getDisplayName();
+    const objectConstructorName = schemaDisplayName ?? (object.constructor ? object.constructor.name : 'Object');
+
+    return (
+      <React.Fragment>
+        <span style={styles.objectDescription as React.CSSProperties}>
+          {objectConstructorName === 'Object' ? '' : `${objectConstructorName} `}
+        </span>
+        <span style={styles.preview as React.CSSProperties}>
+          {'{'}
+          {intersperse(propertyNodes, ', ')}
+          {'}'}
+        </span>
+      </React.Fragment>
+    );
+  }
+};

--- a/src/schema/SchemaAwareObjectValue.tsx
+++ b/src/schema/SchemaAwareObjectValue.tsx
@@ -1,0 +1,39 @@
+import React, { FC } from 'react';
+import { useSchemaContext } from './SchemaContext';
+
+export interface SchemaAwareObjectValueProps {
+  object: unknown;
+  styles?: React.CSSProperties;
+  /** The original ObjectValue component to wrap */
+  ObjectValue: FC<{ object: unknown; styles?: React.CSSProperties }>;
+}
+
+/**
+ * Wrapper component that adds Effect Schema support to ObjectValue.
+ * Uses schema annotations to enrich the display:
+ * - `pretty` annotation for custom value formatting
+ * - `title` or `identifier` annotation for type names
+ */
+export const SchemaAwareObjectValue: FC<SchemaAwareObjectValueProps> = ({ object, styles, ObjectValue }) => {
+  const schemaCtx = useSchemaContext();
+
+  const prettyFormatted = schemaCtx.formatValue(object);
+  if (prettyFormatted !== undefined) {
+    return <span>{prettyFormatted}</span>;
+  }
+
+  if (
+    typeof object === 'object' &&
+    object !== null &&
+    !(object instanceof Date) &&
+    !(object instanceof RegExp) &&
+    !Array.isArray(object)
+  ) {
+    const schemaDisplayName = schemaCtx.getDisplayName();
+    if (schemaDisplayName && object.constructor?.name === 'Object') {
+      return <span>{schemaDisplayName}</span>;
+    }
+  }
+
+  return <ObjectValue object={object} styles={styles} />;
+};

--- a/src/schema/SchemaContext.tsx
+++ b/src/schema/SchemaContext.tsx
@@ -1,0 +1,183 @@
+import React, { createContext, useContext, FC, ReactNode, useMemo } from 'react';
+import type { Schema as S } from 'effect';
+import {
+  type SchemaAnnotations,
+  type SchemaRegistry,
+  getAnnotations,
+  getFieldSchema,
+  getArrayElementSchema,
+  createSchemaRegistry,
+  registerSchema,
+  lookupSchema,
+  formatWithPretty,
+  getDisplayName,
+} from './effectSchema';
+
+export interface SchemaContextValue {
+  /** The current schema for the data being inspected */
+  schema?: S.Schema.All;
+  /** The root schema (stays constant during tree traversal) */
+  rootSchema?: S.Schema.All;
+  /** Registry of schemas for looking up by constructor name */
+  registry: SchemaRegistry;
+  /** Get annotations for the current schema */
+  getAnnotations: () => SchemaAnnotations;
+  /** Get display name for the current value (from schema annotations) */
+  getDisplayName: () => string | undefined;
+  /** Format a value using schema's pretty annotation */
+  formatValue: (value: unknown) => string | undefined;
+  /** Get schema context for a child field */
+  getFieldContext: (fieldName: string) => SchemaContextValue;
+  /** Get schema context for array elements */
+  getElementContext: () => SchemaContextValue;
+  /** Look up a schema by name from registry */
+  lookupByName: (name: string) => S.Schema.All | undefined;
+  /** Get schema for a path like "$.address.street" or "$[0].name" */
+  getSchemaForPath: (path: string) => S.Schema.All | undefined;
+  /** Get schema context for a path */
+  getContextForPath: (path: string) => SchemaContextValue;
+}
+
+const defaultContextValue: SchemaContextValue = {
+  schema: undefined,
+  rootSchema: undefined,
+  registry: createSchemaRegistry(),
+  getAnnotations: () => ({}),
+  getDisplayName: () => undefined,
+  formatValue: () => undefined,
+  getFieldContext: () => defaultContextValue,
+  getElementContext: () => defaultContextValue,
+  lookupByName: () => undefined,
+  getSchemaForPath: () => undefined,
+  getContextForPath: () => defaultContextValue,
+};
+
+const SchemaContext = createContext<SchemaContextValue>(defaultContextValue);
+
+export interface SchemaProviderProps {
+  children: ReactNode;
+  /** Schema for the data being inspected */
+  schema?: S.Schema.All;
+  /** Additional schemas to register for lookup by name */
+  schemas?: S.Schema.All[];
+}
+
+/**
+ * Parse a TreeView path into segments.
+ * Paths look like: "$", "$.address", "$.items.0", "$.items.0.name"
+ */
+const parsePathSegments = (path: string): string[] => {
+  if (path === '$') return [];
+  // Remove leading "$." and split by "."
+  const withoutRoot = path.startsWith('$.') ? path.slice(2) : path.slice(1);
+  return withoutRoot.split('.');
+};
+
+/**
+ * Resolve a schema by traversing path segments from root schema.
+ */
+const resolveSchemaForSegments = (
+  rootSchema: S.Schema.All | undefined,
+  segments: string[]
+): S.Schema.All | undefined => {
+  if (!rootSchema) return undefined;
+  let current: S.Schema.All | undefined = rootSchema;
+
+  for (const segment of segments) {
+    if (!current) return undefined;
+
+    // Check if segment is a numeric index (array access)
+    if (/^\d+$/.test(segment)) {
+      current = getArrayElementSchema(current);
+    } else {
+      current = getFieldSchema(current, segment);
+    }
+  }
+
+  return current;
+};
+
+/** Create a context value for a given schema and registry */
+const createContextValue = (
+  schema: S.Schema.All | undefined,
+  registry: SchemaRegistry,
+  rootSchema?: S.Schema.All
+): SchemaContextValue => {
+  const effectiveRootSchema = rootSchema ?? schema;
+
+  const ctx: SchemaContextValue = {
+    schema,
+    rootSchema: effectiveRootSchema,
+    registry,
+    getAnnotations: () => (schema ? getAnnotations(schema) : {}),
+    getDisplayName: () => (schema ? getDisplayName(getAnnotations(schema)) : undefined),
+    formatValue: (value: unknown) => (schema ? formatWithPretty(value, getAnnotations(schema)) : undefined),
+    getFieldContext: (fieldName: string) => {
+      if (!schema) return createContextValue(undefined, registry, effectiveRootSchema);
+      const fieldSchema = getFieldSchema(schema, fieldName);
+      return createContextValue(fieldSchema, registry, effectiveRootSchema);
+    },
+    getElementContext: () => {
+      if (!schema) return createContextValue(undefined, registry, effectiveRootSchema);
+      const elementSchema = getArrayElementSchema(schema);
+      return createContextValue(elementSchema, registry, effectiveRootSchema);
+    },
+    lookupByName: (name: string) => lookupSchema(registry, name),
+    getSchemaForPath: (path: string) => {
+      const segments = parsePathSegments(path);
+      return resolveSchemaForSegments(effectiveRootSchema, segments);
+    },
+    getContextForPath: (path: string) => {
+      const segments = parsePathSegments(path);
+      const pathSchema = resolveSchemaForSegments(effectiveRootSchema, segments);
+      return createContextValue(pathSchema, registry, effectiveRootSchema);
+    },
+  };
+
+  return ctx;
+};
+
+export const SchemaProvider: FC<SchemaProviderProps> = ({ children, schema, schemas = [] }) => {
+  const value = useMemo(() => {
+    const registry = createSchemaRegistry();
+
+    if (schema) {
+      registerSchema(registry, schema);
+    }
+
+    for (const s of schemas) {
+      registerSchema(registry, s);
+    }
+
+    return createContextValue(schema, registry);
+  }, [schema, schemas]);
+
+  return <SchemaContext.Provider value={value}>{children}</SchemaContext.Provider>;
+};
+
+export const useSchemaContext = (): SchemaContextValue => {
+  return useContext(SchemaContext);
+};
+
+/** Hook to get schema-derived display info for a value */
+export const useSchemaDisplayInfo = (
+  value: unknown,
+  fieldName?: string
+): {
+  displayName?: string;
+  formattedValue?: string;
+  hasSchema: boolean;
+} => {
+  const ctx = useSchemaContext();
+
+  const effectiveCtx = fieldName ? ctx.getFieldContext(fieldName) : ctx;
+
+  const displayName = effectiveCtx.getDisplayName();
+  const formattedValue = effectiveCtx.formatValue(value);
+
+  return {
+    displayName,
+    formattedValue,
+    hasSchema: !!effectiveCtx.schema,
+  };
+};

--- a/src/schema/effectSchema.tsx
+++ b/src/schema/effectSchema.tsx
@@ -1,0 +1,107 @@
+import type { Schema as S, SchemaAST } from 'effect';
+
+/** Symbols used by Effect Schema for annotations */
+const IdentifierAnnotationId = Symbol.for('effect/annotation/Identifier');
+const TitleAnnotationId = Symbol.for('effect/annotation/Title');
+const DescriptionAnnotationId = Symbol.for('effect/annotation/Description');
+const PrettyAnnotationId = Symbol.for('effect/annotation/Pretty');
+
+export interface SchemaAnnotations {
+  identifier?: string;
+  title?: string;
+  description?: string;
+  pretty?: (value: unknown) => string;
+}
+
+/** Extract annotations from a Schema AST node */
+export const getAnnotationsFromAST = (ast: SchemaAST.AST): SchemaAnnotations => {
+  const annotations = ast.annotations;
+  return {
+    identifier: annotations[IdentifierAnnotationId] as string | undefined,
+    title: annotations[TitleAnnotationId] as string | undefined,
+    description: annotations[DescriptionAnnotationId] as string | undefined,
+    pretty: annotations[PrettyAnnotationId] as ((value: unknown) => string) | undefined,
+  };
+};
+
+/** Extract annotations from a Schema */
+export const getAnnotations = (schema: S.Schema.All): SchemaAnnotations => {
+  return getAnnotationsFromAST(schema.ast);
+};
+
+/** Get display name from schema annotations (prefer title, fallback to identifier) */
+export const getDisplayName = (annotations: SchemaAnnotations): string | undefined => {
+  return annotations.title ?? annotations.identifier;
+};
+
+/** Format a value using the schema's pretty annotation if available */
+export const formatWithPretty = (value: unknown, annotations: SchemaAnnotations): string | undefined => {
+  if (annotations.pretty) {
+    try {
+      return annotations.pretty(value);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+};
+
+/** Check if an object might be an Effect Schema (duck typing for optional dependency) */
+export const isEffectSchema = (obj: unknown): obj is S.Schema.All => {
+  return (
+    obj !== null &&
+    typeof obj === 'object' &&
+    'ast' in obj &&
+    typeof (obj as { ast: unknown }).ast === 'object' &&
+    (obj as { ast: { annotations?: unknown } }).ast !== null &&
+    'annotations' in ((obj as { ast: { annotations?: unknown } }).ast ?? {})
+  );
+};
+
+/** Try to find a matching schema for a Struct field */
+export const getFieldSchema = (schema: S.Schema.All, fieldName: string): S.Schema.All | undefined => {
+  const ast = schema.ast;
+
+  if (ast._tag === 'TypeLiteral' && 'propertySignatures' in ast) {
+    const typeLiteralAst = ast as SchemaAST.TypeLiteral;
+    const propSig = typeLiteralAst.propertySignatures.find((sig) => sig.name === fieldName);
+    if (propSig) {
+      return { ast: propSig.type } as S.Schema.All;
+    }
+  }
+
+  return undefined;
+};
+
+/** Get schema for array elements if the schema is an array/tuple */
+export const getArrayElementSchema = (schema: S.Schema.All): S.Schema.All | undefined => {
+  const ast = schema.ast;
+
+  if (ast._tag === 'TupleType' && 'rest' in ast) {
+    const tupleAst = ast as SchemaAST.TupleType;
+    if (tupleAst.rest.length > 0) {
+      return { ast: tupleAst.rest[0].type } as S.Schema.All;
+    }
+  }
+
+  return undefined;
+};
+
+export type SchemaRegistry = Map<string, S.Schema.All>;
+
+/** Create a schema registry for matching schemas to constructor names */
+export const createSchemaRegistry = (): SchemaRegistry => new Map();
+
+/** Register a schema with its identifier/title for lookup */
+export const registerSchema = (registry: SchemaRegistry, schema: S.Schema.All, name?: string): void => {
+  const annotations = getAnnotations(schema);
+  const key = name ?? annotations.identifier ?? annotations.title;
+  if (key) {
+    registry.set(key, schema);
+  }
+};
+
+/** Look up a schema by constructor name or other identifier */
+export const lookupSchema = (registry: SchemaRegistry, name: string): S.Schema.All | undefined => {
+  return registry.get(name);
+};

--- a/src/schema/mod.tsx
+++ b/src/schema/mod.tsx
@@ -1,0 +1,31 @@
+export {
+  type SchemaAnnotations,
+  type SchemaRegistry,
+  getAnnotations,
+  getAnnotationsFromAST,
+  getDisplayName,
+  formatWithPretty,
+  isEffectSchema,
+  getFieldSchema,
+  getArrayElementSchema,
+  createSchemaRegistry,
+  registerSchema,
+  lookupSchema,
+} from './effectSchema';
+
+export {
+  type SchemaContextValue,
+  type SchemaProviderProps,
+  SchemaProvider,
+  useSchemaContext,
+  useSchemaDisplayInfo,
+} from './SchemaContext';
+
+export {
+  withSchemaSupport,
+  withSchemaContext,
+  type SchemaAwareObjectInspectorDeps,
+} from './SchemaAwareObjectInspector';
+export { createSchemaAwareNodeRenderer } from './SchemaAwareNodeRenderer';
+export { SchemaAwareObjectValue } from './SchemaAwareObjectValue';
+export { SchemaAwareObjectPreview } from './SchemaAwareObjectPreview';

--- a/stories/effect-schema.stories.tsx
+++ b/stories/effect-schema.stories.tsx
@@ -1,0 +1,324 @@
+import React from 'react';
+import { Schema } from 'effect';
+
+import {
+  Inspector,
+  ObjectInspector,
+  ObjectRootLabel,
+  ObjectLabel,
+  ObjectName,
+  ObjectValue,
+  ObjectPreview,
+  withSchemaSupport,
+  SchemaProvider,
+} from '../src';
+
+export default {
+  title: 'Effect Schema',
+  component: Inspector,
+};
+
+/** Create a schema-aware version of ObjectInspector using the HOC */
+const SchemaObjectInspector = withSchemaSupport(ObjectInspector, {
+  ObjectRootLabel,
+  ObjectLabel,
+  ObjectName,
+  ObjectValue,
+  ObjectPreview,
+});
+
+/** User schema with title annotation */
+const UserSchema = Schema.Struct({
+  id: Schema.Number,
+  name: Schema.String,
+  email: Schema.String,
+  createdAt: Schema.DateFromSelf,
+}).annotations({
+  identifier: 'User',
+  title: 'User',
+});
+
+type User = typeof UserSchema.Type;
+
+const sampleUser: User = {
+  id: 1,
+  name: 'John Doe',
+  email: 'john@example.com',
+  createdAt: new Date('2024-01-15'),
+};
+
+export const BasicSchemaWithTitle = {
+  render: () => <SchemaObjectInspector data={sampleUser} schema={UserSchema} expandLevel={1} />,
+  name: 'Schema with title annotation',
+};
+
+/** Product schema with pretty print annotation */
+const PriceSchema = Schema.Number.annotations({
+  identifier: 'Price',
+  pretty: (value) => `$${(value as number).toFixed(2)}`,
+});
+
+const ProductSchema = Schema.Struct({
+  id: Schema.Number,
+  name: Schema.String,
+  price: PriceSchema,
+  quantity: Schema.Number,
+}).annotations({
+  identifier: 'Product',
+  title: 'Product',
+});
+
+type Product = typeof ProductSchema.Type;
+
+const sampleProduct: Product = {
+  id: 42,
+  name: 'Widget Pro',
+  price: 29.99,
+  quantity: 100,
+};
+
+export const SchemaWithPrettyPrint = {
+  render: () => <SchemaObjectInspector data={sampleProduct} schema={ProductSchema} expandLevel={1} />,
+  name: 'Schema with pretty print annotation',
+};
+
+/** Address schema for nested structures */
+const AddressSchema = Schema.Struct({
+  street: Schema.String,
+  city: Schema.String,
+  country: Schema.String,
+  zip: Schema.String,
+}).annotations({
+  identifier: 'Address',
+  title: 'Address',
+});
+
+/** Person schema with nested address */
+const PersonSchema = Schema.Struct({
+  id: Schema.Number,
+  name: Schema.String,
+  address: AddressSchema,
+}).annotations({
+  identifier: 'Person',
+  title: 'Person',
+});
+
+type Person = typeof PersonSchema.Type;
+
+const samplePerson: Person = {
+  id: 1,
+  name: 'Jane Smith',
+  address: {
+    street: '123 Main St',
+    city: 'San Francisco',
+    country: 'USA',
+    zip: '94102',
+  },
+};
+
+export const NestedSchemaWithAnnotations = {
+  render: () => <SchemaObjectInspector data={samplePerson} schema={PersonSchema} expandLevel={2} />,
+  name: 'Nested schema with annotations',
+};
+
+/** Temperature schema with pretty print for formatting */
+const TemperatureSchema = Schema.Number.annotations({
+  identifier: 'Temperature',
+  pretty: (value) => `${value}°C`,
+});
+
+/** Weather report schema */
+const WeatherReportSchema = Schema.Struct({
+  location: Schema.String,
+  temperature: TemperatureSchema,
+  humidity: Schema.Number.annotations({
+    pretty: (value) => `${value}%`,
+  }),
+  conditions: Schema.String,
+}).annotations({
+  identifier: 'WeatherReport',
+  title: 'Weather Report',
+});
+
+type WeatherReport = typeof WeatherReportSchema.Type;
+
+const sampleWeather: WeatherReport = {
+  location: 'New York',
+  temperature: 22,
+  humidity: 65,
+  conditions: 'Partly Cloudy',
+};
+
+export const PrettyPrintForMultipleFields = {
+  render: () => <SchemaObjectInspector data={sampleWeather} schema={WeatherReportSchema} expandLevel={1} />,
+  name: 'Pretty print for multiple fields',
+};
+
+/** Array of users example */
+const UsersArraySchema = Schema.Array(UserSchema).annotations({
+  identifier: 'Users',
+  title: 'Users',
+});
+
+const sampleUsers: User[] = [
+  { id: 1, name: 'Alice', email: 'alice@example.com', createdAt: new Date('2024-01-01') },
+  { id: 2, name: 'Bob', email: 'bob@example.com', createdAt: new Date('2024-02-15') },
+  { id: 3, name: 'Charlie', email: 'charlie@example.com', createdAt: new Date('2024-03-20') },
+];
+
+export const ArrayOfSchemaItems = {
+  render: () => <SchemaObjectInspector data={sampleUsers} schema={UsersArraySchema} expandLevel={2} />,
+  name: 'Array of schema items',
+};
+
+/** Example without schema for comparison */
+export const WithoutSchema = {
+  render: () => <ObjectInspector data={sampleUser} expandLevel={1} />,
+  name: 'Without schema (for comparison)',
+};
+
+/** Order schema with complex formatting */
+const MoneySchema = Schema.Number.annotations({
+  identifier: 'Money',
+  pretty: (value) => {
+    const num = value as number;
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(num);
+  },
+});
+
+const OrderItemSchema = Schema.Struct({
+  productId: Schema.Number,
+  name: Schema.String,
+  price: MoneySchema,
+  quantity: Schema.Number,
+}).annotations({
+  identifier: 'OrderItem',
+  title: 'Order Item',
+});
+
+const OrderSchema = Schema.Struct({
+  orderId: Schema.String,
+  customer: Schema.String,
+  items: Schema.Array(OrderItemSchema),
+  subtotal: MoneySchema,
+  tax: MoneySchema,
+  total: MoneySchema,
+  status: Schema.String,
+}).annotations({
+  identifier: 'Order',
+  title: 'Order',
+});
+
+type Order = typeof OrderSchema.Type;
+
+const sampleOrder: Order = {
+  orderId: 'ORD-2024-001',
+  customer: 'John Doe',
+  items: [
+    { productId: 1, name: 'Widget Pro', price: 29.99, quantity: 2 },
+    { productId: 2, name: 'Gadget Plus', price: 49.99, quantity: 1 },
+  ],
+  subtotal: 109.97,
+  tax: 9.9,
+  total: 119.87,
+  status: 'Shipped',
+};
+
+export const ComplexOrderExample = {
+  render: () => <SchemaObjectInspector data={sampleOrder} schema={OrderSchema} expandLevel={3} />,
+  name: 'Complex order with currency formatting',
+};
+
+/** Enum-like union type example */
+const StatusSchema = Schema.Union(
+  Schema.Literal('pending'),
+  Schema.Literal('processing'),
+  Schema.Literal('completed'),
+  Schema.Literal('cancelled')
+).annotations({
+  identifier: 'OrderStatus',
+  title: 'Order Status',
+});
+
+const TaskSchema = Schema.Struct({
+  id: Schema.Number,
+  title: Schema.String,
+  status: StatusSchema,
+  priority: Schema.Number.annotations({
+    pretty: (value) => {
+      const num = value as number;
+      if (num >= 8) return 'High';
+      if (num >= 4) return 'Medium';
+      return 'Low';
+    },
+  }),
+}).annotations({
+  identifier: 'Task',
+  title: 'Task',
+});
+
+type Task = typeof TaskSchema.Type;
+
+const sampleTask: Task = {
+  id: 1,
+  title: 'Implement Effect Schema support',
+  status: 'completed',
+  priority: 9,
+};
+
+export const TaskWithPriorityFormatting = {
+  render: () => <SchemaObjectInspector data={sampleTask} schema={TaskSchema} expandLevel={1} />,
+  name: 'Task with priority formatting',
+};
+
+/** Using top-level pretty print for an entire object */
+const PointSchema = Schema.Struct({
+  x: Schema.Number,
+  y: Schema.Number,
+}).annotations({
+  identifier: 'Point',
+  title: 'Point',
+  pretty: (value) => {
+    const point = value as { x: number; y: number };
+    return `(${point.x}, ${point.y})`;
+  },
+});
+
+type Point = typeof PointSchema.Type;
+
+const samplePoint: Point = { x: 10, y: 20 };
+
+export const ObjectWithTopLevelPrettyPrint = {
+  render: () => <SchemaObjectInspector data={samplePoint} schema={PointSchema} />,
+  name: 'Object with top-level pretty print',
+};
+
+/** Comparison: same data with and without schema */
+export const ComparisonWithAndWithoutSchema = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '40px' }}>
+      <div>
+        <h4 style={{ marginBottom: '8px' }}>With Schema</h4>
+        <SchemaObjectInspector data={sampleOrder} schema={OrderSchema} expandLevel={2} />
+      </div>
+      <div>
+        <h4 style={{ marginBottom: '8px' }}>Without Schema</h4>
+        <ObjectInspector data={sampleOrder} expandLevel={2} />
+      </div>
+    </div>
+  ),
+  name: 'Comparison: with and without schema',
+};
+
+/** Example using SchemaProvider directly for more control */
+export const UsingSchemaProviderDirectly = {
+  render: () => (
+    <SchemaProvider schema={UserSchema}>
+      <ObjectInspector data={sampleUser} expandLevel={1} />
+    </SchemaProvider>
+  ),
+  name: 'Using SchemaProvider directly',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -948,6 +948,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@overeng/react-inspector@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@overeng/react-inspector@workspace:."
+  dependencies:
+    "@storybook/react": "npm:^9.1.4"
+    "@storybook/react-vite": "npm:^9.1.4"
+    "@testing-library/dom": "npm:^10.4.1"
+    "@testing-library/react": "npm:^16.3.0"
+    "@testing-library/user-event": "npm:^14.6.1"
+    "@types/is-dom": "npm:^1.1.2"
+    "@types/react": "npm:^19.1.12"
+    "@typescript-eslint/eslint-plugin": "npm:^8.42.0"
+    "@typescript-eslint/parser": "npm:^8.42.0"
+    auto: "npm:^11.3.0"
+    chromatic: "npm:^13.1.4"
+    eslint: "npm:^9.34.0"
+    eslint-config-prettier: "npm:^10.1.8"
+    eslint-plugin-prettier: "npm:^5.5.4"
+    eslint-plugin-storybook: "npm:^9.1.4"
+    happy-dom: "npm:^18.0.1"
+    is-dom: "npm:^1.1.0"
+    prettier: "npm:^3.6.2"
+    react: "npm:^19.1.1"
+    react-dom: "npm:^19.1.1"
+    react-test-renderer: "npm:^19.1.1"
+    storybook: "npm:^9.1.4"
+    tsup: "npm:^8.5.0"
+    typescript: "npm:^5.9.2"
+    vite: "npm:^7.1.4"
+    vitest: "npm:^3.2.4"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+  languageName: unknown
+  linkType: soft
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -4559,41 +4594,6 @@ __metadata:
   checksum: 10c0/8c91198510521299c56e4e8d5e3a4508b2734fb5e52f29eeac33811de64e76fe586ad32c32182e2e84e070d98df67125da346c3360013357228172dbcd20bcdd
   languageName: node
   linkType: hard
-
-"react-inspector@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "react-inspector@workspace:."
-  dependencies:
-    "@storybook/react": "npm:^9.1.4"
-    "@storybook/react-vite": "npm:^9.1.4"
-    "@testing-library/dom": "npm:^10.4.1"
-    "@testing-library/react": "npm:^16.3.0"
-    "@testing-library/user-event": "npm:^14.6.1"
-    "@types/is-dom": "npm:^1.1.2"
-    "@types/react": "npm:^19.1.12"
-    "@typescript-eslint/eslint-plugin": "npm:^8.42.0"
-    "@typescript-eslint/parser": "npm:^8.42.0"
-    auto: "npm:^11.3.0"
-    chromatic: "npm:^13.1.4"
-    eslint: "npm:^9.34.0"
-    eslint-config-prettier: "npm:^10.1.8"
-    eslint-plugin-prettier: "npm:^5.5.4"
-    eslint-plugin-storybook: "npm:^9.1.4"
-    happy-dom: "npm:^18.0.1"
-    is-dom: "npm:^1.1.0"
-    prettier: "npm:^3.6.2"
-    react: "npm:^19.1.1"
-    react-dom: "npm:^19.1.1"
-    react-test-renderer: "npm:^19.1.1"
-    storybook: "npm:^9.1.4"
-    tsup: "npm:^8.5.0"
-    typescript: "npm:^5.9.2"
-    vite: "npm:^7.1.4"
-    vitest: "npm:^3.2.4"
-  peerDependencies:
-    react: ^18.0.0 || ^19.0.0
-  languageName: unknown
-  linkType: soft
 
 "react-is@npm:^17.0.1":
   version: 17.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -963,6 +963,7 @@ __metadata:
     "@typescript-eslint/parser": "npm:^8.42.0"
     auto: "npm:^11.3.0"
     chromatic: "npm:^13.1.4"
+    effect: "npm:^3.12.5"
     eslint: "npm:^9.34.0"
     eslint-config-prettier: "npm:^10.1.8"
     eslint-plugin-prettier: "npm:^5.5.4"
@@ -979,7 +980,11 @@ __metadata:
     vite: "npm:^7.1.4"
     vitest: "npm:^3.2.4"
   peerDependencies:
+    effect: ^3.0.0
     react: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    effect:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -1157,6 +1162,13 @@ __metadata:
   version: 4.50.0
   resolution: "@rollup/rollup-win32-x64-msvc@npm:4.50.0"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@standard-schema/spec@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
   languageName: node
   linkType: hard
 
@@ -2417,6 +2429,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"effect@npm:^3.12.5":
+  version: 3.19.12
+  resolution: "effect@npm:3.19.12"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.0.0"
+    fast-check: "npm:^3.23.1"
+  checksum: 10c0/4efee01519dae9fd274192d411441337c4c86dd71cd5b77c4174fc5558963965aa77c715c7bca2cc51aee5316e30a3de620ce10d6687e55a3310b207588084eb
+  languageName: node
+  linkType: hard
+
 "electron-to-chromium@npm:^1.5.211":
   version: 1.5.212
   resolution: "electron-to-chromium@npm:1.5.212"
@@ -2844,6 +2866,15 @@ __metadata:
   version: 3.1.2
   resolution: "exponential-backoff@npm:3.1.2"
   checksum: 10c0/d9d3e1eafa21b78464297df91f1776f7fbaa3d5e3f7f0995648ca5b89c069d17055033817348d9f4a43d1c20b0eab84f75af6991751e839df53e4dfd6f22e844
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^3.23.1":
+  version: 3.23.2
+  resolution: "fast-check@npm:3.23.2"
+  dependencies:
+    pure-rand: "npm:^6.1.0"
+  checksum: 10c0/16fcff3c80321ee765e23c3aebd0f6427f175c9c6c1753104ec658970162365dc2d56bda046d815e8f2e90634c07ba7d6f0bcfd327fbd576d98c56a18a9765ed
   languageName: node
   linkType: hard
 
@@ -4533,6 +4564,13 @@ __metadata:
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
+  languageName: node
+  linkType: hard
+
+"pure-rand@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "pure-rand@npm:6.1.0"
+  checksum: 10c0/1abe217897bf74dcb3a0c9aba3555fe975023147b48db540aa2faf507aee91c03bf54f6aef0eb2bf59cc259a16d06b28eca37f0dc426d94f4692aeff02fb0e65
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds optional Effect Schema integration to display type names, custom formatting via pretty annotations, and proper nested schema support. All new code is isolated in `src/schema/` with minimal changes to existing files for easy maintenance and upstream sync.

## Test plan

- View effect-schema stories in storybook to see type names, pretty formatting, and nested schema support in action
- Verify that ObjectInspector works normally without schemas (backward compatible)
- Check that images display correctly in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)